### PR TITLE
Cleanup httpd.conf

### DIFF
--- a/templates/cinder/config/httpd.conf
+++ b/templates/cinder/config/httpd.conf
@@ -12,8 +12,6 @@ Listen 8776
 TypesConfig /etc/mime.types
 
 Include conf.modules.d/*.conf
-# XXX: To disable SSL
-#Include conf.d/*.conf
 
 LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
 LogFormat "%{X-Forwarded-For}i %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" proxy
@@ -22,29 +20,7 @@ SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
 CustomLog /dev/stdout combined env=!forwarded
 CustomLog /dev/stdout proxy env=forwarded
 
-<VirtualHost *:8776>
-  ServerName cinder.openstack.svc
-
-  ## Vhost docroot
-  DocumentRoot "/var/www/cgi-bin/cinder"
-
-  ## Directories, there should at least be a declaration for /var/www/cgi-bin/cinder
-
-  <Directory "/var/www/cgi-bin/cinder">
-    Options -Indexes +FollowSymLinks +MultiViews
-    AllowOverride None
-    Require all granted
-  </Directory>
-
-  ## Logging
-  ErrorLog /dev/stdout
-  ServerSignature Off
-  CustomLog /dev/stdout combined 
-  SetEnvIf X-Forwarded-Proto https HTTPS=1
-
-  ## WSGI configuration
-  WSGIApplicationGroup %{GLOBAL}
-  WSGIDaemonProcess cinder-api display-name=cinder_wsgi group=cinder processes=4 threads=1 user=cinder
-  WSGIProcessGroup cinder-api
-  WSGIScriptAlias / "/var/www/cgi-bin/cinder/cinder-wsgi"
-</VirtualHost>
+# XXX: To disable SSL
+#Include conf.d/*.conf
+# If above include is commented include at least the cinder wsgi file
+Include conf.d/10-cinder_wsgi.conf


### PR DESCRIPTION
The current WSGI VirtualHost for Cinder API is a big dirty.

We have the same VirtualHost configuration in 2 files, `10-cinder_wsgi.conf` and `httpd.conf` which makes it hard to know which one is actually being used.

The reason why it's duplicated is because we currently have the inclusion of the whole `conf.d` directory where `10-cinder_wsgi.conf` resides commented to disable SSL.

This patch cleans this up a bit and makes sure that we only have the VirtualHost configured in one place, `10-cinder_wsgi.conf` and we either include the configuration files from `conf.d` file or explicitly the Cinder wsgi configuration.

This removes confusion.