### PR TITLE
Fix ConfigMap generation ignores failures

### DIFF
--- a/controllers/cinder_controller.go
+++ b/controllers/cinder_controller.go
@@ -680,7 +680,7 @@ func (r *CinderReconciler) generateServiceConfigMaps(
 
 	err = configmap.EnsureConfigMaps(ctx, h, instance, cms, envVars)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
Failures during the rendering and creation of the Config Maps are being ignored.

This patch changes this behavior and make generation failures prevent the operator from advancing in the process of deploying Cinder, after all without the Config Maps the services will not run as expected or not run at all.