### PR TITLE
Fix debug mode

### DIFF
--- a/pkg/cinderapi/deployment.go
+++ b/pkg/cinderapi/deployment.go
@@ -62,12 +62,7 @@ func Deployment(
 				"/bin/true",
 			},
 		}
-
-		readinessProbe.Exec = &corev1.ExecAction{
-			Command: []string{
-				"/bin/true",
-			},
-		}
+		readinessProbe.Exec = livenessProbe.Exec
 	} else {
 		args = append(args, ServiceCommand)
 		//
@@ -77,10 +72,7 @@ func Deployment(
 			Path: "/healthcheck",
 			Port: intstr.IntOrString{Type: intstr.Int, IntVal: int32(cinder.CinderPublicPort)},
 		}
-		readinessProbe.HTTPGet = &corev1.HTTPGetAction{
-			Path: "/healthcheck",
-			Port: intstr.IntOrString{Type: intstr.Int, IntVal: int32(cinder.CinderPublicPort)},
-		}
+		readinessProbe.HTTPGet = livenessProbe.HTTPGet
 	}
 
 	envVars := map[string]env.Setter{}

--- a/pkg/cinderbackup/statefulset.go
+++ b/pkg/cinderbackup/statefulset.go
@@ -69,12 +69,6 @@ func StatefulSet(
 				"/bin/true",
 			},
 		}
-
-		readinessProbe.Exec = &corev1.ExecAction{
-			Command: []string{
-				"/bin/true",
-			},
-		}
 	} else {
 		args = append(args, ServiceCommand)
 		livenessProbe.Exec = &corev1.ExecAction{
@@ -83,21 +77,9 @@ func StatefulSet(
 				"cinder-backup",
 			},
 		}
-
-		readinessProbe.Exec = &corev1.ExecAction{
-			Command: []string{
-				"/usr/local/bin/container-scripts/healthcheck.sh",
-				"cinder-backup",
-			},
-		}
-
-		startupProbe.Exec = &corev1.ExecAction{
-			Command: []string{
-				"/usr/local/bin/container-scripts/healthcheck.sh",
-				"cinder-backup",
-			},
-		}
 	}
+	readinessProbe.Exec = livenessProbe.Exec
+	startupProbe.Exec = livenessProbe.Exec
 
 	envVars := map[string]env.Setter{}
 	envVars["KOLLA_CONFIG_FILE"] = env.SetValue(KollaConfig)

--- a/pkg/cinderscheduler/statefulset.go
+++ b/pkg/cinderscheduler/statefulset.go
@@ -69,12 +69,6 @@ func StatefulSet(
 				"/bin/true",
 			},
 		}
-
-		readinessProbe.Exec = &corev1.ExecAction{
-			Command: []string{
-				"/bin/true",
-			},
-		}
 	} else {
 		args = append(args, ServiceCommand)
 		livenessProbe.Exec = &corev1.ExecAction{
@@ -83,21 +77,9 @@ func StatefulSet(
 				"cinder-scheduler",
 			},
 		}
-
-		readinessProbe.Exec = &corev1.ExecAction{
-			Command: []string{
-				"/usr/local/bin/container-scripts/healthcheck.sh",
-				"cinder-scheduler",
-			},
-		}
-
-		startupProbe.Exec = &corev1.ExecAction{
-			Command: []string{
-				"/usr/local/bin/container-scripts/healthcheck.sh",
-				"cinder-scheduler",
-			},
-		}
 	}
+	readinessProbe.Exec = livenessProbe.Exec
+	startupProbe.Exec = livenessProbe.Exec
 
 	envVars := map[string]env.Setter{}
 	envVars["KOLLA_CONFIG_FILE"] = env.SetValue(KollaConfig)

--- a/pkg/cindervolume/statefulset.go
+++ b/pkg/cindervolume/statefulset.go
@@ -70,12 +70,6 @@ func StatefulSet(
 				"/bin/true",
 			},
 		}
-
-		readinessProbe.Exec = &corev1.ExecAction{
-			Command: []string{
-				"/bin/true",
-			},
-		}
 	} else {
 		args = append(args, ServiceCommand)
 		livenessProbe.Exec = &corev1.ExecAction{
@@ -84,21 +78,9 @@ func StatefulSet(
 				"cinder-volume",
 			},
 		}
-
-		readinessProbe.Exec = &corev1.ExecAction{
-			Command: []string{
-				"/usr/local/bin/container-scripts/healthcheck.sh",
-				"cinder-volume",
-			},
-		}
-
-		startupProbe.Exec = &corev1.ExecAction{
-			Command: []string{
-				"/usr/local/bin/container-scripts/healthcheck.sh",
-				"cinder-volume",
-			},
-		}
 	}
+	readinessProbe.Exec = livenessProbe.Exec
+	startupProbe.Exec = livenessProbe.Exec
 
 	envVars := map[string]env.Setter{}
 	envVars["KOLLA_CONFIG_FILE"] = env.SetValue(KollaConfig)


### PR DESCRIPTION
The operator will fail to deploy Cinder volume, backup, and scheduler containers when the Service is set to debug mode:

  debug:
    service: true

This is because the startup probe will be missing an execution command.

In this patch we simply add the same dummy check for the startup probe as we do in the liveness and readiness probes and make a small change in the different probe exec setting to use the same instance for all probes instead of creating different instances with the same contents for each probe.