### PR TITLE
Rename keystone package name to keystonev1

### DIFF
--- a/controllers/cinder_controller.go
+++ b/controllers/cinder_controller.go
@@ -32,7 +32,7 @@ import (
 	"github.com/go-logr/logr"
 	cinderv1beta1 "github.com/openstack-k8s-operators/cinder-operator/api/v1beta1"
 	"github.com/openstack-k8s-operators/cinder-operator/pkg/cinder"
-	keystone "github.com/openstack-k8s-operators/keystone-operator/api/v1beta1"
+	keystonev1 "github.com/openstack-k8s-operators/keystone-operator/api/v1beta1"
 	"github.com/openstack-k8s-operators/lib-common/modules/common"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/configmap"
@@ -626,7 +626,7 @@ func (r *CinderReconciler) generateServiceConfigMaps(
 		customData[key] = data
 	}
 
-	keystoneAPI, err := keystone.GetKeystoneAPI(ctx, h, instance.Namespace, map[string]string{})
+	keystoneAPI, err := keystonev1.GetKeystoneAPI(ctx, h, instance.Namespace, map[string]string{})
 	if err != nil {
 		return err
 	}

--- a/controllers/cinderapi_controller.go
+++ b/controllers/cinderapi_controller.go
@@ -39,7 +39,7 @@ import (
 	cinderv1beta1 "github.com/openstack-k8s-operators/cinder-operator/api/v1beta1"
 	"github.com/openstack-k8s-operators/cinder-operator/pkg/cinder"
 	cinderapi "github.com/openstack-k8s-operators/cinder-operator/pkg/cinderapi"
-	keystone "github.com/openstack-k8s-operators/keystone-operator/api/v1beta1"
+	keystonev1 "github.com/openstack-k8s-operators/keystone-operator/api/v1beta1"
 	"github.com/openstack-k8s-operators/lib-common/modules/common"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/configmap"
@@ -235,7 +235,7 @@ func (r *CinderAPIReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&cinderv1beta1.CinderAPI{}).
-		Owns(&keystone.KeystoneService{}).
+		Owns(&keystonev1.KeystoneService{}).
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Secret{}).
 		Owns(&routev1.Route{}).
@@ -253,7 +253,7 @@ func (r *CinderAPIReconciler) reconcileDelete(ctx context.Context, instance *cin
 	if instance.Status.APIEndpoints != nil {
 		for _, ksSvc := range keystoneServices {
 
-			ks, err := keystone.GetKeystoneServiceWithName(ctx, helper, ksSvc["name"], instance.Namespace)
+			ks, err := keystonev1.GetKeystoneServiceWithName(ctx, helper, ksSvc["name"], instance.Namespace)
 
 			if err != nil && !k8s_errors.IsNotFound(err) {
 				return ctrl.Result{}, err
@@ -263,7 +263,7 @@ func (r *CinderAPIReconciler) reconcileDelete(ctx context.Context, instance *cin
 			// (we do it this way because we want to make sure the "RemoveFinalizer" call is
 			// executed even if the KeystoneService no longer exists)
 			if !k8s_errors.IsNotFound(err) {
-				ksSvcObj := keystone.NewKeystoneService(ks.Spec, instance.Namespace, map[string]string{}, 10)
+				ksSvcObj := keystonev1.NewKeystoneService(ks.Spec, instance.Namespace, map[string]string{}, 10)
 				err = ksSvcObj.Delete(ctx, helper)
 
 				if err != nil {
@@ -411,7 +411,7 @@ func (r *CinderAPIReconciler) reconcileInit(
 	}
 
 	for _, ksSvc := range keystoneServices {
-		ksSvcSpec := keystone.KeystoneServiceSpec{
+		ksSvcSpec := keystonev1.KeystoneServiceSpec{
 			ServiceType:        ksSvc["type"],
 			ServiceName:        ksSvc["name"],
 			ServiceDescription: ksSvc["desc"],
@@ -422,7 +422,7 @@ func (r *CinderAPIReconciler) reconcileInit(
 			PasswordSelector:   instance.Spec.PasswordSelectors.Service,
 		}
 
-		ksSvcObj := keystone.NewKeystoneService(ksSvcSpec, instance.Namespace, serviceLabels, 10)
+		ksSvcObj := keystonev1.NewKeystoneService(ksSvcSpec, instance.Namespace, serviceLabels, 10)
 		ctrlResult, err = ksSvcObj.CreateOrPatch(ctx, helper)
 		if err != nil {
 			return ctrlResult, err


### PR DESCRIPTION
When updating to the latest keystone-operator API on commit 57dfebea4265254cd44b3cb87e27048902ddd460 we unified the assigned package name as "keystone", which diverges from what other openstack operators are doing.

This patch renames all instances to "keystonev1" to be consistent with the other operators.