### PR TITLE
Fix backups

### DIFF
--- a/pkg/cinderbackup/statefulset.go
+++ b/pkg/cinderbackup/statefulset.go
@@ -38,6 +38,7 @@ func StatefulSet(
 	configHash string,
 	labels map[string]string,
 ) *appsv1.StatefulSet {
+	trueVar := true
 	runAsUser := int64(0)
 
 	// TODO until we determine how to properly query for these
@@ -111,7 +112,8 @@ func StatefulSet(
 							Args:  args,
 							Image: instance.Spec.ContainerImage,
 							SecurityContext: &corev1.SecurityContext{
-								RunAsUser: &runAsUser,
+								RunAsUser:  &runAsUser,
+								Privileged: &trueVar,
 							},
 							Env:            env.MergeEnvs([]corev1.EnvVar{}, envVars),
 							VolumeMounts:   GetVolumeMounts(),

--- a/templates/cinder/config/cinder-backup-config.json
+++ b/templates/cinder/config/cinder-backup-config.json
@@ -12,7 +12,18 @@
       "dest": "/etc/cinder/nfs_shares",
       "owner": "root:cinder",
       "perm": "0640"
+    },
+    {
+      "source": "/var/lib/config-data/merged/ceph.conf",
+      "dest": "/etc/ceph/ceph.conf",
+      "owner": "root:cinder",
+      "perm": "0600"
+    },
+    {
+      "source": "/var/lib/config-data/merged/ceph.client.openstack.keyring",
+      "dest": "/etc/ceph/ceph.client.{{ .User }}.keyring",
+      "owner": "root:cinder",
+      "perm": "0600"
     }
-
   ]
 }


### PR DESCRIPTION
This PR fixes a couple of things in the cinder-backup services:

- Fixes the support for the Ceph Backup driver (currently doesn't have the required files).
- Make the cinder-backup container privileged.