### PR TITLE
Use keystone catalog info for Glance

### DIFF
--- a/templates/cinder/config/cinder.conf
+++ b/templates/cinder/config/cinder.conf
@@ -1,8 +1,11 @@
 [DEFAULT]
 # transport_url = rabbit://openstack:RABBIT_PASS@controller
 auth_strategy = keystone
-# TODO
-glance_api_servers=http://glanceapi.openstack.svc:9292/
+# TODO: Decide if we want the operator to generate the api servers, which is
+#       more efficient when creating volumes from image (no keystone requests).
+#       For now rely on checking the catalog info
+#       glance_api_servers=http://glanceapi.openstack.svc:9292/
+glance_catalog_info value = image:glance:internalURL
 storage_availability_zone = nova
 default_availability_zone = nova
 # TODO: should we create our own default type


### PR DESCRIPTION
Our current cinder.conf template hardcodes the Glance server, which means that operators will need to set this manually.

This patch changes this to use the Keystone catalog instead, telling cinder to check for Glance's internal endpoint to get the actual address.

This seems like a sane default, because even if it is slower due to the additional request to keystone, it has the benefit of always working and automatically adapting to any changes.

In the future we could make the operator set the glance_api_servers itself checking the OpenShift service and then add a watcher to it so it can react if it were to change.

That would give users the best of both worlds, speed and automatic updates of cinder.conf on changes.