### PR TITLE
Reduce memory consumption in Cinder services

### DIFF
--- a/pkg/cinderbackup/statefulset.go
+++ b/pkg/cinderbackup/statefulset.go
@@ -86,6 +86,14 @@ func StatefulSet(
 	envVars["KOLLA_CONFIG_STRATEGY"] = env.SetValue("COPY_ALWAYS")
 	envVars["CONFIG_HASH"] = env.SetValue(configHash)
 
+	// Tune glibc for reduced memory usage and fragmentation using single malloc arena for all
+	// threads and disabling dynamic thresholds to reduce memory usage when using native threads
+	// directly or via eventlet.tpool
+	// https://www.gnu.org/software/libc/manual/html_node/Memory-Allocation-Tunables.html
+	envVars["MALLOC_ARENA_MAX"] = env.SetValue("1")
+	envVars["MALLOC_MMAP_THRESHOLD_"] = env.SetValue("131072")
+	envVars["MALLOC_TRIM_THRESHOLD_"] = env.SetValue("262144")
+
 	statefulset := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      instance.Name,

--- a/pkg/cindervolume/statefulset.go
+++ b/pkg/cindervolume/statefulset.go
@@ -87,6 +87,14 @@ func StatefulSet(
 	envVars["KOLLA_CONFIG_STRATEGY"] = env.SetValue("COPY_ALWAYS")
 	envVars["CONFIG_HASH"] = env.SetValue(configHash)
 
+	// Tune glibc for reduced memory usage and fragmentation using single malloc arena for all
+	// threads and disabling dynamic thresholds to reduce memory usage when using native threads
+	// directly or via eventlet.tpool
+	// https://www.gnu.org/software/libc/manual/html_node/Memory-Allocation-Tunables.html
+	envVars["MALLOC_ARENA_MAX"] = env.SetValue("1")
+	envVars["MALLOC_MMAP_THRESHOLD_"] = env.SetValue("131072")
+	envVars["MALLOC_TRIM_THRESHOLD_"] = env.SetValue("262144")
+
 	statefulset := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      instance.Name,


### PR DESCRIPTION
This patch reduces memory usage on the Cinder Volume and Backup services by tuning glibc.

The specific tuning consist on disabling the per thread arenas and disabling dynamic thresholds.

The Cinder Backup service suffers from high water mark memory usage and uses excessive memory.  As an example just after 10 restore operations the service uses almost 1GB of RAM and does not ever free it afterwards. With this patch the memory consumption of the service is reduced down to almost 130MB and memory consumption during runtime is also halved.

This patch is the equivalent to OpenStack patches:

- DevStack: https://review.opendev.org/c/openstack/devstack/+/845805
- TripleO: https://review.opendev.org/c/openstack/tripleo-common/+/845807

Information on glibc tuning is available at:
https://www.gnu.org/software/libc/manual/html_node/Memory-Allocation-Tunables.html