### PR TITLE
Using internal Glance URL

### DIFF
--- a/templates/cinder/config/cinder.conf
+++ b/templates/cinder/config/cinder.conf
@@ -5,7 +5,7 @@ auth_strategy = keystone
 #       more efficient when creating volumes from image (no keystone requests).
 #       For now rely on checking the catalog info
 #       glance_api_servers=http://glanceapi.openstack.svc:9292/
-glance_catalog_info value = image:glance:internalURL
+glance_catalog_info = image:glance:internalURL
 storage_availability_zone = nova
 default_availability_zone = nova
 # TODO: should we create our own default type


### PR DESCRIPTION
On commit a6aaee5063adb533226d8e2a25b742c42ebdd158 we intended to change the way we get the Glance server addresses from using a hardcoded address to using the Keystone internal Glance URL catalog entry, but due to a mistake the service is using the public one instead (default when value not defined).

This patch fixes this and Cinder will use the intended internal URL instead.

This fixes the mistake from https://github.com/openstack-k8s-operators/cinder-operator/pull/32