### PR TITLE
Update makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,12 +149,12 @@ ifndef ignore-not-found
 endif
 
 .PHONY: install
-install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build config/crd | kubectl apply -f -
+install: manifests kustomize ## Install CRDs and RBAC into the K8s cluster specified in ~/.kube/config.
+	$(KUSTOMIZE) build config/dev | kubectl apply -f -
 
 .PHONY: uninstall
-uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
-	$(KUSTOMIZE) build config/crd | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
+uninstall: manifests kustomize ## Uninstall CRDs and RBAC from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
+	$(KUSTOMIZE) build config/dev | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,8 @@ BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(VERSION)
 # BUNDLE_GEN_FLAGS are the flags passed to the operator-sdk generate bundle command
 BUNDLE_GEN_FLAGS ?= -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
 
+VERIFY_TLS ?= true
+
 # USE_IMAGE_DIGESTS defines if images are resolved via tags or digests
 # You can enable this value if you would like to use SHA Based Digests
 # To enable set flag to true
@@ -134,7 +136,7 @@ docker-build: test ## Build docker image with the manager.
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
-	podman push ${IMG}
+	podman push --tls-verify=${VERIFY_TLS} ${IMG}
 
 ##@ Deployment
 

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,8 @@ ifeq ($(USE_IMAGE_DIGESTS), true)
 endif
 
 # Image URL to use all building/pushing image targets
-IMG ?= controller:latest
+DEFAULT_IMG ?= quay.io/openstack-k8s-operators/cinder-operator:latest
+IMG ?= $(DEFAULT_IMG)
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.24.1
 
@@ -136,6 +137,9 @@ docker-build: test ## Build docker image with the manager.
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
+ifeq ($(IMG), $(DEFAULT_IMG))
+	$(error As a precaution this target cannot push the default image. If that's really your intentention you'll need to do it manually.)
+endif
 	podman push --tls-verify=${VERIFY_TLS} ${IMG}
 
 ##@ Deployment

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,18 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
+# Project is OpenShift centered, so we use oc instead of kubectl, but the
+# operator-sdk uses kubectl.
+# To avoid errors try to create a kubectl symlink to oc when there's no kubectl.
+# Won't create it if oc is in a dir requiring sudo to write.
+ifeq ($(shell which kubectl 2>/dev/null),)
+	ifeq ($(shell which oc 2>/dev/null),)
+		res := $(warning Command "oc" and "kubectl" missing, some targets may fail)
+	else
+		res := $(shell ln -s oc `dirname \`which oc\``/kubectl)
+	endif
+endif
+
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # This is a requirement for 'setup-envtest.sh' in the test target.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,5 +1,5 @@
 # Adds namespace to all resources.
-namespace: cinder-operator-system
+namespace: openstack
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named

--- a/config/dev/kustomization.yaml
+++ b/config/dev/kustomization.yaml
@@ -1,0 +1,5 @@
+namespace: openstack
+namePrefix: cinder-operator-
+bases:
+- ../crd
+- ../rbac

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -1,10 +1,3 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  labels:
-    control-plane: controller-manager
-  name: system
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
These patches change our Makefile to make our life easier as developers:

- Removes the need to have the `kubectl` command, using `oc` instead.
- Add support to pushing to insecure registries
- `make deploy` will work as it is after using the meta-operator.
- `install/uninstall` targets will not only take care of CRDs but also RBACs.