### PR TITLE
Max 1 replica for volume

### DIFF
--- a/api/v1beta1/cindervolume_types.go
+++ b/api/v1beta1/cindervolume_types.go
@@ -35,6 +35,7 @@ type CinderVolumeSpec struct {
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=1
+	// +kubebuilder:validation:Maximum=1
 	// Replicas - Cinder Volume Replicas
 	Replicas int32 `json:"replicas"`
 

--- a/config/crd/bases/cinder.openstack.org_cinders.yaml
+++ b/config/crd/bases/cinder.openstack.org_cinders.yaml
@@ -509,6 +509,7 @@ spec:
                       default: 1
                       description: Replicas - Cinder Volume Replicas
                       format: int32
+                      maximum: 1
                       type: integer
                     resources:
                       description: Resources - Compute Resources required by this

--- a/config/crd/bases/cinder.openstack.org_cindervolumes.yaml
+++ b/config/crd/bases/cinder.openstack.org_cindervolumes.yaml
@@ -111,6 +111,7 @@ spec:
                 default: 1
                 description: Replicas - Cinder Volume Replicas
                 format: int32
+                maximum: 1
                 type: integer
               resources:
                 description: Resources - Compute Resources required by this service


### PR DESCRIPTION
We currently only support Active-Passive deployments for the cinder-volume service since we haven't resolved yet the whole DLM situation or how to know if the driver supports Active-Active.

For this reason we'll limit the number of replicas supported for the volume backends to 1 through the validations.