### PR TITLE
Drop registry.redhat.io login from github action

### DIFF
--- a/.github/workflows/build-cinder-operator.yaml
+++ b/.github/workflows/build-cinder-operator.yaml
@@ -100,13 +100,6 @@ jobs:
         username: ${{ secrets.QUAY_USERNAME }}
         password: ${{ secrets.QUAY_PASSWORD }}
 
-    - name: Log in to Red Hat Registry
-      uses: redhat-actions/podman-login@v1
-      with:
-        registry: registry.redhat.io
-        username: ${{ secrets.REDHATIO_USERNAME }}
-        password: ${{ secrets.REDHATIO_PASSWORD }}
-
     - name: Create bundle image
       run: |
         pushd "${GITHUB_WORKSPACE}"/.github/


### PR DESCRIPTION
Only required if we are converting image tags to shas and reference registry.redhat.io images.