### PR TITLE
Copy rendered CRD files dir to /api/bases in make manifests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,9 @@ help: ## Display this help.
 
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases && \
+	rm -f api/bases/* && cp -a config/crd/bases api/
+
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.

--- a/api/bases/cinder.openstack.org_cinderapis.yaml
+++ b/api/bases/cinder.openstack.org_cinderapis.yaml
@@ -1,0 +1,221 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+  creationTimestamp: null
+  name: cinderapis.cinder.openstack.org
+spec:
+  group: cinder.openstack.org
+  names:
+    kind: CinderAPI
+    listKind: CinderAPIList
+    plural: cinderapis
+    singular: cinderapi
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: CinderAPI is the Schema for the cinderapis API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CinderAPISpec defines the desired state of CinderAPI
+            properties:
+              containerImage:
+                description: ContainerImage - Cinder API Container Image URL
+                type: string
+              customServiceConfig:
+                default: '# add your customization here'
+                description: CustomServiceConfig - customize the service config using
+                  this parameter to change service defaults, or overwrite rendered
+                  information using raw OpenStack config format. The content gets
+                  added to to /etc/<service>/<service>.conf.d directory as custom.conf
+                  file.
+                type: string
+              databaseHostname:
+                description: DatabaseHostname - Cinder Database Hostname
+                type: string
+              databaseUser:
+                default: cinder
+                description: 'DatabaseUser - optional username used for cinder DB,
+                  defaults to cinder TODO: -> implement needs work in mariadb-operator,
+                  right now only cinder'
+                type: string
+              debug:
+                description: Debug - enable debug for different deploy stages. If
+                  an init container is used, it runs and the actual action pod gets
+                  started with sleep infinity
+                properties:
+                  initContainer:
+                    default: false
+                    description: initContainer enable debug (waits until /tmp/stop-init-container
+                      disappears)
+                    type: boolean
+                  service:
+                    default: false
+                    description: service enable debug
+                    type: boolean
+                type: object
+              defaultConfigOverwrite:
+                additionalProperties:
+                  type: string
+                description: 'ConfigOverwrite - interface to overwrite default config
+                  files like e.g. policy.json. But can also be used to add additional
+                  files. Those get added to the service config dir in /etc/<service>
+                  . TODO: -> implement'
+                type: object
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: NodeSelector to target subset of worker nodes for running
+                  the API service
+                type: object
+              passwordSelectors:
+                description: PasswordSelectors - Selectors to identify the DB and
+                  AdminUser password and TransportURL from the Secret
+                properties:
+                  admin:
+                    default: CinderPassword
+                    description: Database - Selector to get the cinder service password
+                      from the Secret
+                    type: string
+                  database:
+                    default: CinderDatabasePassword
+                    description: 'Database - Selector to get the cinder database user
+                      password from the Secret TODO: not used, need change in mariadb-operator'
+                    type: string
+                  transportUrl:
+                    default: TransportURL
+                    description: Database - Selector to get the cinder service password
+                      from the Secret
+                    type: string
+                type: object
+              replicas:
+                default: 1
+                description: Replicas - Cinder API Replicas
+                format: int32
+                type: integer
+              resources:
+                description: Resources - Compute Resources required by this service
+                  (Limits/Requests). https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                properties:
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Limits describes the maximum amount of compute resources
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Requests describes the minimum amount of compute
+                      resources required. If Requests is omitted for a container,
+                      it defaults to Limits if that is explicitly specified, otherwise
+                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                type: object
+              secret:
+                description: Secret containing OpenStack password information for
+                  CinderDatabasePassword, AdminPassword
+                type: string
+              serviceUser:
+                default: cinder
+                description: ServiceUser - optional username used for this service
+                  to register in cinder
+                type: string
+            type: object
+          status:
+            description: CinderAPIStatus defines the observed state of CinderAPI
+            properties:
+              apiEndpoints:
+                additionalProperties:
+                  additionalProperties:
+                    type: string
+                  type: object
+                description: API endpoints
+                type: object
+              conditions:
+                description: Conditions
+                items:
+                  description: Condition defines an observation of a API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase.
+                      type: string
+                    severity:
+                      description: Severity provides a classification of Reason code,
+                        so the current situation is immediately understandable and
+                        could act accordingly. It is meant for situations where Status=False
+                        and it should be indicated if it is just informational, warning
+                        (next reconciliation might fix it) or an error (e.g. DB create
+                        issue and no actions to automatically resolve the issue can/should
+                        be done). For conditions where Status=Unknown or Status=True
+                        the Severity should be SeverityNone.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              hash:
+                additionalProperties:
+                  type: string
+                description: Map of hashes to track e.g. job status
+                type: object
+              readyCount:
+                description: ReadyCount of Cinder API instances
+                format: int32
+                type: integer
+              serviceIDs:
+                additionalProperties:
+                  type: string
+                description: ServiceIDs
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/api/bases/cinder.openstack.org_cinderbackups.yaml
+++ b/api/bases/cinder.openstack.org_cinderbackups.yaml
@@ -1,0 +1,208 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+  creationTimestamp: null
+  name: cinderbackups.cinder.openstack.org
+spec:
+  group: cinder.openstack.org
+  names:
+    kind: CinderBackup
+    listKind: CinderBackupList
+    plural: cinderbackups
+    singular: cinderbackup
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: CinderBackup is the Schema for the cinderbackups API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CinderBackupSpec defines the desired state of CinderBackup
+            properties:
+              containerImage:
+                description: ContainerImage - Cinder Backup Container Image URL
+                type: string
+              customServiceConfig:
+                default: '# add your customization here'
+                description: CustomServiceConfig - customize the service config using
+                  this parameter to change service defaults, or overwrite rendered
+                  information using raw OpenStack config format. The content gets
+                  added to to /etc/<service>/<service>.conf.d directory as custom.conf
+                  file.
+                type: string
+              databaseHostname:
+                description: DatabaseHostname - Cinder Database Hostname
+                type: string
+              databaseUser:
+                default: cinder
+                description: 'DatabaseUser - optional username used for cinder DB,
+                  defaults to cinder TODO: -> implement needs work in mariadb-operator,
+                  right now only cinder'
+                type: string
+              debug:
+                description: Debug - enable debug for different deploy stages. If
+                  an init container is used, it runs and the actual action pod gets
+                  started with sleep infinity
+                properties:
+                  initContainer:
+                    default: false
+                    description: initContainer enable debug (waits until /tmp/stop-init-container
+                      disappears)
+                    type: boolean
+                  service:
+                    default: false
+                    description: service enable debug
+                    type: boolean
+                type: object
+              defaultConfigOverwrite:
+                additionalProperties:
+                  type: string
+                description: 'ConfigOverwrite - interface to overwrite default config
+                  files like e.g. policy.json. But can also be used to add additional
+                  files. Those get added to the service config dir in /etc/<service>
+                  . TODO: -> implement'
+                type: object
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: NodeSelector to target subset of worker nodes for running
+                  the Backup service
+                type: object
+              passwordSelectors:
+                description: PasswordSelectors - Selectors to identify the DB and
+                  TransportURL from the Secret
+                properties:
+                  admin:
+                    default: CinderPassword
+                    description: Database - Selector to get the cinder service password
+                      from the Secret
+                    type: string
+                  database:
+                    default: CinderDatabasePassword
+                    description: 'Database - Selector to get the cinder database user
+                      password from the Secret TODO: not used, need change in mariadb-operator'
+                    type: string
+                  transportUrl:
+                    default: TransportURL
+                    description: Database - Selector to get the cinder service password
+                      from the Secret
+                    type: string
+                type: object
+              replicas:
+                description: Replicas - Cinder Backup Replicas
+                format: int32
+                type: integer
+              resources:
+                description: Resources - Compute Resources required by this service
+                  (Limits/Requests). https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                properties:
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Limits describes the maximum amount of compute resources
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Requests describes the minimum amount of compute
+                      resources required. If Requests is omitted for a container,
+                      it defaults to Limits if that is explicitly specified, otherwise
+                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                type: object
+              secret:
+                description: Secret containing OpenStack password information for
+                  CinderDatabasePassword
+                type: string
+              serviceUser:
+                default: cinder
+                description: ServiceUser - optional username used for this service
+                  to register in cinder
+                type: string
+            type: object
+          status:
+            description: CinderBackupStatus defines the observed state of CinderBackup
+            properties:
+              conditions:
+                description: Conditions
+                items:
+                  description: Condition defines an observation of a API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase.
+                      type: string
+                    severity:
+                      description: Severity provides a classification of Reason code,
+                        so the current situation is immediately understandable and
+                        could act accordingly. It is meant for situations where Status=False
+                        and it should be indicated if it is just informational, warning
+                        (next reconciliation might fix it) or an error (e.g. DB create
+                        issue and no actions to automatically resolve the issue can/should
+                        be done). For conditions where Status=Unknown or Status=True
+                        the Severity should be SeverityNone.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              hash:
+                additionalProperties:
+                  type: string
+                description: Map of hashes to track e.g. job status
+                type: object
+              readyCount:
+                description: ReadyCount of Cinder Backup instances
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/api/bases/cinder.openstack.org_cinders.yaml
+++ b/api/bases/cinder.openstack.org_cinders.yaml
@@ -1,0 +1,712 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+  creationTimestamp: null
+  name: cinders.cinder.openstack.org
+spec:
+  group: cinder.openstack.org
+  names:
+    kind: Cinder
+    listKind: CinderList
+    plural: cinders
+    singular: cinder
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Cinder is the Schema for the cinders API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CinderSpec defines the desired state of Cinder
+            properties:
+              cephBackend:
+                description: CephBackend - The ceph Backend structure with all the
+                  parameters
+                properties:
+                  cephClientKey:
+                    description: ClientKey set the Ceph cluster key
+                    type: string
+                  cephFsid:
+                    description: ClusterFSID defines the fsid
+                    type: string
+                  cephMons:
+                    description: ClusterMons defines the commma separated mon list
+                    type: string
+                  cephPools:
+                    additionalProperties:
+                      description: PoolSpec defines the Ceph pool Spec parameters
+                      properties:
+                        name:
+                          description: PoolName defines the name of the pool
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    description: Pools - Map of chosen names to spec definitions for
+                      the Ceph cluster pools
+                    type: object
+                  cephUser:
+                    default: CephUser
+                    description: User set the Ceph cluster pool
+                    type: string
+                required:
+                - cephClientKey
+                - cephFsid
+                - cephMons
+                type: object
+              cinderAPI:
+                description: CinderAPI - Spec definition for the API service of this
+                  Cinder deployment
+                properties:
+                  containerImage:
+                    description: ContainerImage - Cinder API Container Image URL
+                    type: string
+                  customServiceConfig:
+                    default: '# add your customization here'
+                    description: CustomServiceConfig - customize the service config
+                      using this parameter to change service defaults, or overwrite
+                      rendered information using raw OpenStack config format. The
+                      content gets added to to /etc/<service>/<service>.conf.d directory
+                      as custom.conf file.
+                    type: string
+                  databaseHostname:
+                    description: DatabaseHostname - Cinder Database Hostname
+                    type: string
+                  databaseUser:
+                    default: cinder
+                    description: 'DatabaseUser - optional username used for cinder
+                      DB, defaults to cinder TODO: -> implement needs work in mariadb-operator,
+                      right now only cinder'
+                    type: string
+                  debug:
+                    description: Debug - enable debug for different deploy stages.
+                      If an init container is used, it runs and the actual action
+                      pod gets started with sleep infinity
+                    properties:
+                      initContainer:
+                        default: false
+                        description: initContainer enable debug (waits until /tmp/stop-init-container
+                          disappears)
+                        type: boolean
+                      service:
+                        default: false
+                        description: service enable debug
+                        type: boolean
+                    type: object
+                  defaultConfigOverwrite:
+                    additionalProperties:
+                      type: string
+                    description: 'ConfigOverwrite - interface to overwrite default
+                      config files like e.g. policy.json. But can also be used to
+                      add additional files. Those get added to the service config
+                      dir in /etc/<service> . TODO: -> implement'
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: NodeSelector to target subset of worker nodes for
+                      running the API service
+                    type: object
+                  passwordSelectors:
+                    description: PasswordSelectors - Selectors to identify the DB
+                      and AdminUser password and TransportURL from the Secret
+                    properties:
+                      admin:
+                        default: CinderPassword
+                        description: Database - Selector to get the cinder service
+                          password from the Secret
+                        type: string
+                      database:
+                        default: CinderDatabasePassword
+                        description: 'Database - Selector to get the cinder database
+                          user password from the Secret TODO: not used, need change
+                          in mariadb-operator'
+                        type: string
+                      transportUrl:
+                        default: TransportURL
+                        description: Database - Selector to get the cinder service
+                          password from the Secret
+                        type: string
+                    type: object
+                  replicas:
+                    default: 1
+                    description: Replicas - Cinder API Replicas
+                    format: int32
+                    type: integer
+                  resources:
+                    description: Resources - Compute Resources required by this service
+                      (Limits/Requests). https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                    type: object
+                  secret:
+                    description: Secret containing OpenStack password information
+                      for CinderDatabasePassword, AdminPassword
+                    type: string
+                  serviceUser:
+                    default: cinder
+                    description: ServiceUser - optional username used for this service
+                      to register in cinder
+                    type: string
+                type: object
+              cinderBackup:
+                description: CinderBackup - Spec definition for the Backup service
+                  of this Cinder deployment
+                properties:
+                  containerImage:
+                    description: ContainerImage - Cinder Backup Container Image URL
+                    type: string
+                  customServiceConfig:
+                    default: '# add your customization here'
+                    description: CustomServiceConfig - customize the service config
+                      using this parameter to change service defaults, or overwrite
+                      rendered information using raw OpenStack config format. The
+                      content gets added to to /etc/<service>/<service>.conf.d directory
+                      as custom.conf file.
+                    type: string
+                  databaseHostname:
+                    description: DatabaseHostname - Cinder Database Hostname
+                    type: string
+                  databaseUser:
+                    default: cinder
+                    description: 'DatabaseUser - optional username used for cinder
+                      DB, defaults to cinder TODO: -> implement needs work in mariadb-operator,
+                      right now only cinder'
+                    type: string
+                  debug:
+                    description: Debug - enable debug for different deploy stages.
+                      If an init container is used, it runs and the actual action
+                      pod gets started with sleep infinity
+                    properties:
+                      initContainer:
+                        default: false
+                        description: initContainer enable debug (waits until /tmp/stop-init-container
+                          disappears)
+                        type: boolean
+                      service:
+                        default: false
+                        description: service enable debug
+                        type: boolean
+                    type: object
+                  defaultConfigOverwrite:
+                    additionalProperties:
+                      type: string
+                    description: 'ConfigOverwrite - interface to overwrite default
+                      config files like e.g. policy.json. But can also be used to
+                      add additional files. Those get added to the service config
+                      dir in /etc/<service> . TODO: -> implement'
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: NodeSelector to target subset of worker nodes for
+                      running the Backup service
+                    type: object
+                  passwordSelectors:
+                    description: PasswordSelectors - Selectors to identify the DB
+                      and TransportURL from the Secret
+                    properties:
+                      admin:
+                        default: CinderPassword
+                        description: Database - Selector to get the cinder service
+                          password from the Secret
+                        type: string
+                      database:
+                        default: CinderDatabasePassword
+                        description: 'Database - Selector to get the cinder database
+                          user password from the Secret TODO: not used, need change
+                          in mariadb-operator'
+                        type: string
+                      transportUrl:
+                        default: TransportURL
+                        description: Database - Selector to get the cinder service
+                          password from the Secret
+                        type: string
+                    type: object
+                  replicas:
+                    description: Replicas - Cinder Backup Replicas
+                    format: int32
+                    type: integer
+                  resources:
+                    description: Resources - Compute Resources required by this service
+                      (Limits/Requests). https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                    type: object
+                  secret:
+                    description: Secret containing OpenStack password information
+                      for CinderDatabasePassword
+                    type: string
+                  serviceUser:
+                    default: cinder
+                    description: ServiceUser - optional username used for this service
+                      to register in cinder
+                    type: string
+                type: object
+              cinderScheduler:
+                description: CinderScheduler - Spec definition for the Scheduler service
+                  of this Cinder deployment
+                properties:
+                  containerImage:
+                    description: ContainerImage - Cinder Scheduler Container Image
+                      URL
+                    type: string
+                  customServiceConfig:
+                    default: '# add your customization here'
+                    description: CustomServiceConfig - customize the service config
+                      using this parameter to change service defaults, or overwrite
+                      rendered information using raw OpenStack config format. The
+                      content gets added to to /etc/<service>/<service>.conf.d directory
+                      as custom.conf file.
+                    type: string
+                  databaseHostname:
+                    description: DatabaseHostname - Cinder Database Hostname
+                    type: string
+                  databaseUser:
+                    default: cinder
+                    description: 'DatabaseUser - optional username used for cinder
+                      DB, defaults to cinder TODO: -> implement needs work in mariadb-operator,
+                      right now only cinder'
+                    type: string
+                  debug:
+                    description: Debug - enable debug for different deploy stages.
+                      If an init container is used, it runs and the actual action
+                      pod gets started with sleep infinity
+                    properties:
+                      initContainer:
+                        default: false
+                        description: initContainer enable debug (waits until /tmp/stop-init-container
+                          disappears)
+                        type: boolean
+                      service:
+                        default: false
+                        description: service enable debug
+                        type: boolean
+                    type: object
+                  defaultConfigOverwrite:
+                    additionalProperties:
+                      type: string
+                    description: 'ConfigOverwrite - interface to overwrite default
+                      config files like e.g. policy.json. But can also be used to
+                      add additional files. Those get added to the service config
+                      dir in /etc/<service> . TODO: -> implement'
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: NodeSelector to target subset of worker nodes for
+                      running the Scheduler service
+                    type: object
+                  passwordSelectors:
+                    description: PasswordSelectors - Selectors to identify the DB
+                      and TransportURL from the Secret
+                    properties:
+                      admin:
+                        default: CinderPassword
+                        description: Database - Selector to get the cinder service
+                          password from the Secret
+                        type: string
+                      database:
+                        default: CinderDatabasePassword
+                        description: 'Database - Selector to get the cinder database
+                          user password from the Secret TODO: not used, need change
+                          in mariadb-operator'
+                        type: string
+                      transportUrl:
+                        default: TransportURL
+                        description: Database - Selector to get the cinder service
+                          password from the Secret
+                        type: string
+                    type: object
+                  replicas:
+                    default: 1
+                    description: Replicas - Cinder Scheduler Replicas
+                    format: int32
+                    type: integer
+                  resources:
+                    description: Resources - Compute Resources required by this service
+                      (Limits/Requests). https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                    type: object
+                  secret:
+                    description: Secret containing OpenStack password information
+                      for CinderDatabasePassword
+                    type: string
+                  serviceUser:
+                    default: cinder
+                    description: ServiceUser - optional username used for this service
+                      to register in cinder
+                    type: string
+                type: object
+              cinderVolumes:
+                additionalProperties:
+                  description: CinderVolumeSpec defines the desired state of CinderVolume
+                  properties:
+                    containerImage:
+                      description: ContainerImage - Cinder Volume Container Image
+                        URL
+                      type: string
+                    customServiceConfig:
+                      default: '# add your customization here'
+                      description: CustomServiceConfig - customize the service config
+                        using this parameter to change service defaults, or overwrite
+                        rendered information using raw OpenStack config format. The
+                        content gets added to to /etc/<service>/<service>.conf.d directory
+                        as custom.conf file.
+                      type: string
+                    databaseHostname:
+                      description: DatabaseHostname - Cinder Database Hostname
+                      type: string
+                    databaseUser:
+                      default: cinder
+                      description: 'DatabaseUser - optional username used for cinder
+                        DB, defaults to cinder TODO: -> implement needs work in mariadb-operator,
+                        right now only cinder'
+                      type: string
+                    debug:
+                      description: Debug - enable debug for different deploy stages.
+                        If an init container is used, it runs and the actual action
+                        pod gets started with sleep infinity
+                      properties:
+                        initContainer:
+                          default: false
+                          description: initContainer enable debug (waits until /tmp/stop-init-container
+                            disappears)
+                          type: boolean
+                        service:
+                          default: false
+                          description: service enable debug
+                          type: boolean
+                      type: object
+                    defaultConfigOverwrite:
+                      additionalProperties:
+                        type: string
+                      description: 'ConfigOverwrite - interface to overwrite default
+                        config files like e.g. policy.json. But can also be used to
+                        add additional files. Those get added to the service config
+                        dir in /etc/<service> . TODO: -> implement'
+                      type: object
+                    nodeSelector:
+                      additionalProperties:
+                        type: string
+                      description: NodeSelector to target subset of worker nodes for
+                        running the Volume service
+                      type: object
+                    passwordSelectors:
+                      description: PasswordSelectors - Selectors to identify the DB
+                        and TransportURL from the Secret
+                      properties:
+                        admin:
+                          default: CinderPassword
+                          description: Database - Selector to get the cinder service
+                            password from the Secret
+                          type: string
+                        database:
+                          default: CinderDatabasePassword
+                          description: 'Database - Selector to get the cinder database
+                            user password from the Secret TODO: not used, need change
+                            in mariadb-operator'
+                          type: string
+                        transportUrl:
+                          default: TransportURL
+                          description: Database - Selector to get the cinder service
+                            password from the Secret
+                          type: string
+                      type: object
+                    replicas:
+                      default: 1
+                      description: Replicas - Cinder Volume Replicas
+                      format: int32
+                      maximum: 1
+                      type: integer
+                    resources:
+                      description: Resources - Compute Resources required by this
+                        service (Limits/Requests). https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute
+                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute
+                            resources required. If Requests is omitted for a container,
+                            it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. More info:
+                            https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          type: object
+                      type: object
+                    secret:
+                      description: Secret containing OpenStack password information
+                        for CinderDatabasePassword
+                      type: string
+                    serviceUser:
+                      default: cinder
+                      description: ServiceUser - optional username used for this service
+                        to register in cinder
+                      type: string
+                  type: object
+                description: CinderVolumes - Map of chosen names to spec definitions
+                  for the Volume(s) service(s) of this Cinder deployment
+                type: object
+              customServiceConfig:
+                default: '# add your customization here'
+                description: CustomServiceConfig - customize the service config for
+                  all Cinder services using this parameter to change service defaults,
+                  or overwrite rendered information using raw OpenStack config format.
+                  The content gets added to to /etc/<service>/<service>.conf.d directory
+                  as custom.conf file.
+                type: string
+              databaseInstance:
+                description: MariaDB instance name Right now required by the maridb-operator
+                  to get the credentials from the instance to create the DB Might
+                  not be required in future
+                type: string
+              databaseUser:
+                default: cinder
+                description: 'DatabaseUser - optional username used for cinder DB,
+                  defaults to cinder TODO: -> implement needs work in mariadb-operator,
+                  right now only cinder'
+                type: string
+              debug:
+                description: Debug - enable debug for different deploy stages. If
+                  an init container is used, it runs and the actual action pod gets
+                  started with sleep infinity
+                properties:
+                  dbInitContainer:
+                    default: false
+                    description: dbInitContainer enable debug (waits until /tmp/stop-init-container
+                      disappears)
+                    type: boolean
+                  dbSync:
+                    default: false
+                    description: dbSync enable debug
+                    type: boolean
+                type: object
+              defaultConfigOverwrite:
+                additionalProperties:
+                  type: string
+                description: 'ConfigOverwrite - interface to overwrite default config
+                  files like e.g. policy.json. But can also be used to add additional
+                  files. Those get added to the service config dir in /etc/<service>
+                  . TODO: -> implement'
+                type: object
+              passwordSelectors:
+                description: PasswordSelectors - Selectors to identify the DB and
+                  AdminUser password and TransportURL from the Secret
+                properties:
+                  admin:
+                    default: CinderPassword
+                    description: Database - Selector to get the cinder service password
+                      from the Secret
+                    type: string
+                  database:
+                    default: CinderDatabasePassword
+                    description: 'Database - Selector to get the cinder database user
+                      password from the Secret TODO: not used, need change in mariadb-operator'
+                    type: string
+                  transportUrl:
+                    default: TransportURL
+                    description: Database - Selector to get the cinder service password
+                      from the Secret
+                    type: string
+                type: object
+              preserveJobs:
+                default: false
+                description: PreserveJobs - do not delete jobs after they finished
+                  e.g. to check logs
+                type: boolean
+              secret:
+                description: Secret containing OpenStack password information for
+                  CinderDatabasePassword, AdminPassword
+                type: string
+              serviceUser:
+                default: cinder
+                description: ServiceUser - optional username used for this service
+                  to register in cinder
+                type: string
+            required:
+            - cinderAPI
+            - cinderScheduler
+            type: object
+          status:
+            description: CinderStatus defines the observed state of Cinder
+            properties:
+              apiEndpoints:
+                additionalProperties:
+                  additionalProperties:
+                    type: string
+                  type: object
+                description: API endpoints
+                type: object
+              cinderAPIReadyCount:
+                description: ReadyCount of Cinder API instance
+                format: int32
+                type: integer
+              cinderBackupReadyCount:
+                description: ReadyCount of Cinder Backup instance
+                format: int32
+                type: integer
+              cinderSchedulerReadyCount:
+                description: ReadyCount of Cinder Scheduler instance
+                format: int32
+                type: integer
+              cinderVolumesReadyCounts:
+                additionalProperties:
+                  format: int32
+                  type: integer
+                description: ReadyCounts of Cinder Volume instances
+                type: object
+              conditions:
+                description: Conditions
+                items:
+                  description: Condition defines an observation of a API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase.
+                      type: string
+                    severity:
+                      description: Severity provides a classification of Reason code,
+                        so the current situation is immediately understandable and
+                        could act accordingly. It is meant for situations where Status=False
+                        and it should be indicated if it is just informational, warning
+                        (next reconciliation might fix it) or an error (e.g. DB create
+                        issue and no actions to automatically resolve the issue can/should
+                        be done). For conditions where Status=Unknown or Status=True
+                        the Severity should be SeverityNone.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              databaseHostname:
+                description: Cinder Database Hostname
+                type: string
+              hash:
+                additionalProperties:
+                  type: string
+                description: Map of hashes to track e.g. job status
+                type: object
+              serviceIDs:
+                additionalProperties:
+                  type: string
+                description: ServiceIDs
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/api/bases/cinder.openstack.org_cinderschedulers.yaml
+++ b/api/bases/cinder.openstack.org_cinderschedulers.yaml
@@ -1,0 +1,209 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+  creationTimestamp: null
+  name: cinderschedulers.cinder.openstack.org
+spec:
+  group: cinder.openstack.org
+  names:
+    kind: CinderScheduler
+    listKind: CinderSchedulerList
+    plural: cinderschedulers
+    singular: cinderscheduler
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: CinderScheduler is the Schema for the cinderschedulers API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CinderSchedulerSpec defines the desired state of CinderScheduler
+            properties:
+              containerImage:
+                description: ContainerImage - Cinder Scheduler Container Image URL
+                type: string
+              customServiceConfig:
+                default: '# add your customization here'
+                description: CustomServiceConfig - customize the service config using
+                  this parameter to change service defaults, or overwrite rendered
+                  information using raw OpenStack config format. The content gets
+                  added to to /etc/<service>/<service>.conf.d directory as custom.conf
+                  file.
+                type: string
+              databaseHostname:
+                description: DatabaseHostname - Cinder Database Hostname
+                type: string
+              databaseUser:
+                default: cinder
+                description: 'DatabaseUser - optional username used for cinder DB,
+                  defaults to cinder TODO: -> implement needs work in mariadb-operator,
+                  right now only cinder'
+                type: string
+              debug:
+                description: Debug - enable debug for different deploy stages. If
+                  an init container is used, it runs and the actual action pod gets
+                  started with sleep infinity
+                properties:
+                  initContainer:
+                    default: false
+                    description: initContainer enable debug (waits until /tmp/stop-init-container
+                      disappears)
+                    type: boolean
+                  service:
+                    default: false
+                    description: service enable debug
+                    type: boolean
+                type: object
+              defaultConfigOverwrite:
+                additionalProperties:
+                  type: string
+                description: 'ConfigOverwrite - interface to overwrite default config
+                  files like e.g. policy.json. But can also be used to add additional
+                  files. Those get added to the service config dir in /etc/<service>
+                  . TODO: -> implement'
+                type: object
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: NodeSelector to target subset of worker nodes for running
+                  the Scheduler service
+                type: object
+              passwordSelectors:
+                description: PasswordSelectors - Selectors to identify the DB and
+                  TransportURL from the Secret
+                properties:
+                  admin:
+                    default: CinderPassword
+                    description: Database - Selector to get the cinder service password
+                      from the Secret
+                    type: string
+                  database:
+                    default: CinderDatabasePassword
+                    description: 'Database - Selector to get the cinder database user
+                      password from the Secret TODO: not used, need change in mariadb-operator'
+                    type: string
+                  transportUrl:
+                    default: TransportURL
+                    description: Database - Selector to get the cinder service password
+                      from the Secret
+                    type: string
+                type: object
+              replicas:
+                default: 1
+                description: Replicas - Cinder Scheduler Replicas
+                format: int32
+                type: integer
+              resources:
+                description: Resources - Compute Resources required by this service
+                  (Limits/Requests). https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                properties:
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Limits describes the maximum amount of compute resources
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Requests describes the minimum amount of compute
+                      resources required. If Requests is omitted for a container,
+                      it defaults to Limits if that is explicitly specified, otherwise
+                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                type: object
+              secret:
+                description: Secret containing OpenStack password information for
+                  CinderDatabasePassword
+                type: string
+              serviceUser:
+                default: cinder
+                description: ServiceUser - optional username used for this service
+                  to register in cinder
+                type: string
+            type: object
+          status:
+            description: CinderSchedulerStatus defines the observed state of CinderScheduler
+            properties:
+              conditions:
+                description: Conditions
+                items:
+                  description: Condition defines an observation of a API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase.
+                      type: string
+                    severity:
+                      description: Severity provides a classification of Reason code,
+                        so the current situation is immediately understandable and
+                        could act accordingly. It is meant for situations where Status=False
+                        and it should be indicated if it is just informational, warning
+                        (next reconciliation might fix it) or an error (e.g. DB create
+                        issue and no actions to automatically resolve the issue can/should
+                        be done). For conditions where Status=Unknown or Status=True
+                        the Severity should be SeverityNone.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              hash:
+                additionalProperties:
+                  type: string
+                description: Map of hashes to track e.g. job status
+                type: object
+              readyCount:
+                description: ReadyCount of Cinder Scheduler instances
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/api/bases/cinder.openstack.org_cindervolumes.yaml
+++ b/api/bases/cinder.openstack.org_cindervolumes.yaml
@@ -1,0 +1,210 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+  creationTimestamp: null
+  name: cindervolumes.cinder.openstack.org
+spec:
+  group: cinder.openstack.org
+  names:
+    kind: CinderVolume
+    listKind: CinderVolumeList
+    plural: cindervolumes
+    singular: cindervolume
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: CinderVolume is the Schema for the cindervolumes API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CinderVolumeSpec defines the desired state of CinderVolume
+            properties:
+              containerImage:
+                description: ContainerImage - Cinder Volume Container Image URL
+                type: string
+              customServiceConfig:
+                default: '# add your customization here'
+                description: CustomServiceConfig - customize the service config using
+                  this parameter to change service defaults, or overwrite rendered
+                  information using raw OpenStack config format. The content gets
+                  added to to /etc/<service>/<service>.conf.d directory as custom.conf
+                  file.
+                type: string
+              databaseHostname:
+                description: DatabaseHostname - Cinder Database Hostname
+                type: string
+              databaseUser:
+                default: cinder
+                description: 'DatabaseUser - optional username used for cinder DB,
+                  defaults to cinder TODO: -> implement needs work in mariadb-operator,
+                  right now only cinder'
+                type: string
+              debug:
+                description: Debug - enable debug for different deploy stages. If
+                  an init container is used, it runs and the actual action pod gets
+                  started with sleep infinity
+                properties:
+                  initContainer:
+                    default: false
+                    description: initContainer enable debug (waits until /tmp/stop-init-container
+                      disappears)
+                    type: boolean
+                  service:
+                    default: false
+                    description: service enable debug
+                    type: boolean
+                type: object
+              defaultConfigOverwrite:
+                additionalProperties:
+                  type: string
+                description: 'ConfigOverwrite - interface to overwrite default config
+                  files like e.g. policy.json. But can also be used to add additional
+                  files. Those get added to the service config dir in /etc/<service>
+                  . TODO: -> implement'
+                type: object
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: NodeSelector to target subset of worker nodes for running
+                  the Volume service
+                type: object
+              passwordSelectors:
+                description: PasswordSelectors - Selectors to identify the DB and
+                  TransportURL from the Secret
+                properties:
+                  admin:
+                    default: CinderPassword
+                    description: Database - Selector to get the cinder service password
+                      from the Secret
+                    type: string
+                  database:
+                    default: CinderDatabasePassword
+                    description: 'Database - Selector to get the cinder database user
+                      password from the Secret TODO: not used, need change in mariadb-operator'
+                    type: string
+                  transportUrl:
+                    default: TransportURL
+                    description: Database - Selector to get the cinder service password
+                      from the Secret
+                    type: string
+                type: object
+              replicas:
+                default: 1
+                description: Replicas - Cinder Volume Replicas
+                format: int32
+                maximum: 1
+                type: integer
+              resources:
+                description: Resources - Compute Resources required by this service
+                  (Limits/Requests). https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                properties:
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Limits describes the maximum amount of compute resources
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Requests describes the minimum amount of compute
+                      resources required. If Requests is omitted for a container,
+                      it defaults to Limits if that is explicitly specified, otherwise
+                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                type: object
+              secret:
+                description: Secret containing OpenStack password information for
+                  CinderDatabasePassword
+                type: string
+              serviceUser:
+                default: cinder
+                description: ServiceUser - optional username used for this service
+                  to register in cinder
+                type: string
+            type: object
+          status:
+            description: CinderVolumeStatus defines the observed state of CinderVolume
+            properties:
+              conditions:
+                description: Conditions
+                items:
+                  description: Condition defines an observation of a API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase.
+                      type: string
+                    severity:
+                      description: Severity provides a classification of Reason code,
+                        so the current situation is immediately understandable and
+                        could act accordingly. It is meant for situations where Status=False
+                        and it should be indicated if it is just informational, warning
+                        (next reconciliation might fix it) or an error (e.g. DB create
+                        issue and no actions to automatically resolve the issue can/should
+                        be done). For conditions where Status=Unknown or Status=True
+                        the Severity should be SeverityNone.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              hash:
+                additionalProperties:
+                  type: string
+                description: Map of hashes to track e.g. job status
+                type: object
+              readyCount:
+                description: ReadyCount of Cinder Volume instances
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}


### PR DESCRIPTION
With the new api sub module, consumer operators just have to import the api submodule. For envtest it is required to install CRD for e.g. keystone-operator and mariadb-operator to be able to use it.

Moving the directory config/crd/bases which holds the generated files in to the api module that they are available with the module and link the dir in the original place does not work as kustomize autodetect fails on symlinked directories [1].

This updates the `generate` Makefile target to copy config/crd/bases to /api on successful generation run.

[1] kubernetes-sigs/kustomize#1886