### PR TITLE
Fix bundle automation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,8 +49,8 @@ ifeq ($(USE_IMAGE_DIGESTS), true)
 endif
 
 # Image URL to use all building/pushing image targets
+IMG ?= controller:latest
 DEFAULT_IMG ?= quay.io/openstack-k8s-operators/cinder-operator:latest
-IMG ?= $(DEFAULT_IMG)
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.24.1
 
@@ -137,9 +137,6 @@ docker-build: test ## Build docker image with the manager.
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
-ifeq ($(IMG), $(DEFAULT_IMG))
-	$(error As a precaution this target cannot push the default image. If that's really your intentention you'll need to do it manually.)
-endif
 	podman push --tls-verify=${VERIFY_TLS} ${IMG}
 
 ##@ Deployment
@@ -164,6 +161,10 @@ deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in
 .PHONY: undeploy
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
 	$(KUSTOMIZE) build config/default | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
+
+.PHONY: deploy-latest
+deploy-latest: IMG=$(DEFAULT_IMG)
+deploy-latest: deploy
 
 ##@ Build Dependencies
 


### PR DESCRIPTION
On commit 44190808a46574c0bdef27d80738713766f627cd I broke the bundle automation when trying to make the `deploy` rule work off the bat not considering (even with a review comment) that there are automation [1] code checking for the specific `controller:latest` string.

In this patch we revert the change made to the `Makefile` file by that patch and create a new rule called `deploy-latest` instead to stay out of the automation way while still providing an easy way for developers to deploy the latest official image without having to enter its location.

The whole commit was not reverted because the namespace part was still wanted.

[1]: https://github.com/openstack-k8s-operators/cinder-operator/blob/master/.github/create_bundle.sh#L50