### PR TITLE
Share os-brick locks between OpenStack services

### DIFF
--- a/pkg/cinder/dbsync.go
+++ b/pkg/cinder/dbsync.go
@@ -55,16 +55,16 @@ func DbSyncJob(instance *cinderv1beta1.Cinder, labels map[string]string) *batchv
 								RunAsUser: &runAsUser,
 							},
 							Env:          env.MergeEnvs([]corev1.EnvVar{}, envVars),
-							VolumeMounts: GetVolumeMounts(),
+							VolumeMounts: GetVolumeMounts(false),
 						},
 					},
-					Volumes: GetVolumes(instance.Name),
+					Volumes: GetVolumes(instance.Name, false),
 				},
 			},
 		},
 	}
 
-	job.Spec.Template.Spec.Volumes = GetVolumes(ServiceName)
+	job.Spec.Template.Spec.Volumes = GetVolumes(ServiceName, false)
 
 	initContainerDetails := APIDetails{
 		ContainerImage:       instance.Spec.CinderAPI.ContainerImage,

--- a/pkg/cinder/volumes.go
+++ b/pkg/cinder/volumes.go
@@ -113,6 +113,28 @@ func GetVolumes(name string, storageSvc bool) []corev1.Volume {
 					},
 				},
 			},
+			// os-brick locks need to be shared between the different volume
+			// consumers (available in OSP18)
+			{
+				Name: "var-locks-brick",
+				VolumeSource: corev1.VolumeSource{
+					HostPath: &corev1.HostPathVolumeSource{
+						Path: "/var/locks/openstack/os-brick",
+						Type: &dirOrCreate,
+					},
+				},
+			},
+			// In OSP17 there is no os-brick specific lock path conf option,
+			// so the global cinder one is used for os-brick locks
+			{
+				Name: "var-locks-cinder",
+				VolumeSource: corev1.VolumeSource{
+					HostPath: &corev1.HostPathVolumeSource{
+						Path: "/var/locks/openstack/cinder",
+						Type: &dirOrCreate,
+					},
+				},
+			},
 		}
 
 		res = append(res, storageVolumes...)
@@ -196,6 +218,16 @@ func GetVolumeMounts(storageSvc bool) []corev1.VolumeMount {
 			{
 				Name:      "var-lib-iscsi",
 				MountPath: "/var/lib/iscsi",
+			},
+			{
+				Name:      "var-locks-brick",
+				MountPath: "/var/locks/openstack/os-brick",
+				ReadOnly:  false,
+			},
+			{
+				Name:      "var-locks-cinder",
+				MountPath: "/var/locks/openstack/cinder",
+				ReadOnly:  false,
 			},
 		}
 		res = append(res, storageVolumeMounts...)

--- a/pkg/cinderapi/volumes.go
+++ b/pkg/cinderapi/volumes.go
@@ -23,7 +23,7 @@ func GetVolumes(parentName string, name string) []corev1.Volume {
 		},
 	}
 
-	return append(cinder.GetVolumes(parentName), backupVolumes...)
+	return append(cinder.GetVolumes(parentName, false), backupVolumes...)
 }
 
 // GetInitVolumeMounts - Cinder API init task VolumeMounts
@@ -40,5 +40,5 @@ func GetInitVolumeMounts() []corev1.VolumeMount {
 
 // GetVolumeMounts - Cinder API VolumeMounts
 func GetVolumeMounts() []corev1.VolumeMount {
-	return cinder.GetVolumeMounts()
+	return cinder.GetVolumeMounts(false)
 }

--- a/pkg/cinderbackup/volumes.go
+++ b/pkg/cinderbackup/volumes.go
@@ -23,7 +23,7 @@ func GetVolumes(parentName string, name string) []corev1.Volume {
 		},
 	}
 
-	return append(cinder.GetVolumes(parentName), backupVolumes...)
+	return append(cinder.GetVolumes(parentName, true), backupVolumes...)
 }
 
 // GetInitVolumeMounts - Cinder Backup init task VolumeMounts
@@ -40,5 +40,5 @@ func GetInitVolumeMounts() []corev1.VolumeMount {
 
 // GetVolumeMounts - Cinder Backup VolumeMounts
 func GetVolumeMounts() []corev1.VolumeMount {
-	return cinder.GetVolumeMounts()
+	return cinder.GetVolumeMounts(true)
 }

--- a/pkg/cinderscheduler/volumes.go
+++ b/pkg/cinderscheduler/volumes.go
@@ -23,7 +23,7 @@ func GetVolumes(parentName string, name string) []corev1.Volume {
 		},
 	}
 
-	return append(cinder.GetVolumes(parentName), schedulerVolumes...)
+	return append(cinder.GetVolumes(parentName, false), schedulerVolumes...)
 }
 
 // GetInitVolumeMounts - Cinder Scheduler init task VolumeMounts
@@ -40,5 +40,5 @@ func GetInitVolumeMounts() []corev1.VolumeMount {
 
 // GetVolumeMounts - Cinder Scheduler VolumeMounts
 func GetVolumeMounts() []corev1.VolumeMount {
-	return cinder.GetVolumeMounts()
+	return cinder.GetVolumeMounts(false)
 }

--- a/pkg/cindervolume/volumes.go
+++ b/pkg/cindervolume/volumes.go
@@ -12,59 +12,10 @@ func GetVolumes(parentName string, name string) []corev1.Volume {
 
 	volumeVolumes := []corev1.Volume{
 		{
-			Name: "etc-iscsi",
-			VolumeSource: corev1.VolumeSource{
-				HostPath: &corev1.HostPathVolumeSource{
-					Path: "/etc/iscsi",
-				},
-			},
-		},
-		{
-			Name: "dev",
-			VolumeSource: corev1.VolumeSource{
-				HostPath: &corev1.HostPathVolumeSource{
-					Path: "/dev",
-				},
-			},
-		},
-		{
-			Name: "lib-modules",
-			VolumeSource: corev1.VolumeSource{
-				HostPath: &corev1.HostPathVolumeSource{
-					Path: "/lib/modules",
-				},
-			},
-		},
-		{
-			Name: "run",
-			VolumeSource: corev1.VolumeSource{
-				HostPath: &corev1.HostPathVolumeSource{
-					Path: "/run",
-				},
-			},
-		},
-		{
-			Name: "sys",
-			VolumeSource: corev1.VolumeSource{
-				HostPath: &corev1.HostPathVolumeSource{
-					Path: "/sys",
-				},
-			},
-		},
-		{
 			Name: "var-lib-cinder",
 			VolumeSource: corev1.VolumeSource{
 				HostPath: &corev1.HostPathVolumeSource{
 					Path: "/var/lib/cinder",
-					Type: &dirOrCreate,
-				},
-			},
-		},
-		{
-			Name: "var-lib-iscsi",
-			VolumeSource: corev1.VolumeSource{
-				HostPath: &corev1.HostPathVolumeSource{
-					Path: "/var/lib/iscsi",
 					Type: &dirOrCreate,
 				},
 			},
@@ -82,7 +33,7 @@ func GetVolumes(parentName string, name string) []corev1.Volume {
 		},
 	}
 
-	return append(cinder.GetVolumes(parentName), volumeVolumes...)
+	return append(cinder.GetVolumes(parentName, true), volumeVolumes...)
 }
 
 // GetInitVolumeMounts - Cinder Volume init task VolumeMounts
@@ -101,36 +52,10 @@ func GetInitVolumeMounts() []corev1.VolumeMount {
 func GetVolumeMounts() []corev1.VolumeMount {
 	volumeVolumeMounts := []corev1.VolumeMount{
 		{
-			Name:      "etc-iscsi",
-			MountPath: "/etc/iscsi",
-			ReadOnly:  true,
-		},
-		{
-			Name:      "dev",
-			MountPath: "/dev",
-		},
-		{
-			Name:      "lib-modules",
-			MountPath: "/lib/modules",
-			ReadOnly:  true,
-		},
-		{
-			Name:      "run",
-			MountPath: "/run",
-		},
-		{
-			Name:      "sys",
-			MountPath: "/sys",
-		},
-		{
 			Name:      "var-lib-cinder",
 			MountPath: "/var/lib/cinder",
 		},
-		{
-			Name:      "var-lib-iscsi",
-			MountPath: "/var/lib/iscsi",
-		},
 	}
 
-	return append(cinder.GetVolumeMounts(), volumeVolumeMounts...)
+	return append(cinder.GetVolumeMounts(true), volumeVolumeMounts...)
 }

--- a/templates/cinder/config/cinder.conf
+++ b/templates/cinder/config/cinder.conf
@@ -75,7 +75,10 @@ project_domain_name = Default
 #auth_type = password
 
 [oslo_concurrency]
-lock_path = /var/lib/cinder/tmp
+lock_path = /var/locks/openstack/cinder
+
+[os_brick]
+lock_path = /var/locks/openstack/os-brick
 
 # default backend for dev
 # Set in volume custom config CM


### PR DESCRIPTION
os-brick file locks need to be shared across all the OpenStack services
that use os-brick and are running on the same host, if we don't there
will be race conditions that make attach/detach operation unexpectedly
fail.

Services that need to share this locks location are cinder-volume,
cinder-backup, and glance when using cinder as a backend.  Nova compute
would also need to share them in an HCI environment, but that won't be
the case here because nova-compute won't be running in OpenShift.

This patch uses the host's `/var/locks` directory to share these locks.

In OSP17 there is a single lock path configuration option for cinder and
os-brick locks, but in OSP18 there is an os-brick specific configuration
option that can be used.

To make the operator compatible with OSP17 and OSP18 cinder-volume and
cinder-backup pods will "share" both file lock locations
`/var/locks/openstack/os-brick` and `/var/locks/openstack/cinder`
through the host.