### PR TITLE
Fix scheduler restart

### DIFF
--- a/templates/cinder/config/cinder.conf
+++ b/templates/cinder/config/cinder.conf
@@ -12,6 +12,13 @@ default_availability_zone = nova
 #default_volume_type = openstack-k8s
 #enabled_backends = nfs
 scheduler_driver = cinder.scheduler.filter_scheduler.FilterScheduler
+
+# Reduce to 30 seconds, from default's 60, the wait to receive 1 service
+# capabilities report from a cinder volume service.  We keep it under the value
+# of service_down_time (default 60) to ensure that the probes don't restart the
+# scheduler.
+scheduler_driver_init_wait_time = 30
+
 # osapi_volume_listen=controller-0.internalapi.redhat.local
 osapi_volume_workers = 4
 control_exchange = openstack


### PR DESCRIPTION
The cinder-scheduler service is getting restarted when the cinder-volume service is not started within 1 minute of the service start.

The reason why this is happening is that the scheduler service does a heartbeat on start, which makes the service appear as up for the next 60 seconds to OpenStack and our healthcheck.py service, and thus makes the startup probe consider the service is successfully running for those 60 seconds.

But because there is no cinder-volume service sending capability reports, the scheduler decides to wait for 60 seconds for one not doing anything but waiting, so no heartbeats are sent.

This means that the scheduler will appear first as UP, then as DOWN for some seconds, and then as UP again, but if the probe checks just as the service is down it will restart the service.

To fix this we change the time the scheduler waits for a capability report (`scheduler_driver_init_wait_time`) to 30 seconds, which is lower than the default 60 seconds a heartbeat makes the service looks UP (`service_down_time`).