### PR TITLE
Fix defaulting PasswordSelectors

### DIFF
--- a/api/bases/cinder.openstack.org_cinderapis.yaml
+++ b/api/bases/cinder.openstack.org_cinderapis.yaml
@@ -85,18 +85,22 @@ spec:
                   the API service
                 type: object
               passwordSelectors:
+                default:
+                  database: CinderDatabasePassword
+                  service: CinderPassword
+                  transportUrl: TransportURL
                 description: PasswordSelectors - Selectors to identify the DB and
-                  AdminUser password and TransportURL from the Secret
+                  ServiceUser password and TransportURL from the Secret
                 properties:
-                  admin:
-                    default: CinderPassword
-                    description: Database - Selector to get the cinder service password
-                      from the Secret
-                    type: string
                   database:
                     default: CinderDatabasePassword
                     description: 'Database - Selector to get the cinder database user
                       password from the Secret TODO: not used, need change in mariadb-operator'
+                    type: string
+                  service:
+                    default: CinderPassword
+                    description: Database - Selector to get the cinder service password
+                      from the Secret
                     type: string
                   transportUrl:
                     default: TransportURL

--- a/api/bases/cinder.openstack.org_cinderbackups.yaml
+++ b/api/bases/cinder.openstack.org_cinderbackups.yaml
@@ -85,18 +85,22 @@ spec:
                   the Backup service
                 type: object
               passwordSelectors:
+                default:
+                  database: CinderDatabasePassword
+                  service: CinderPassword
+                  transportUrl: TransportURL
                 description: PasswordSelectors - Selectors to identify the DB and
-                  TransportURL from the Secret
+                  ServiceUser password and TransportURL from the Secret
                 properties:
-                  admin:
-                    default: CinderPassword
-                    description: Database - Selector to get the cinder service password
-                      from the Secret
-                    type: string
                   database:
                     default: CinderDatabasePassword
                     description: 'Database - Selector to get the cinder database user
                       password from the Secret TODO: not used, need change in mariadb-operator'
+                    type: string
+                  service:
+                    default: CinderPassword
+                    description: Database - Selector to get the cinder service password
+                      from the Secret
                     type: string
                   transportUrl:
                     default: TransportURL

--- a/api/bases/cinder.openstack.org_cinders.yaml
+++ b/api/bases/cinder.openstack.org_cinders.yaml
@@ -133,19 +133,23 @@ spec:
                       running the API service
                     type: object
                   passwordSelectors:
+                    default:
+                      database: CinderDatabasePassword
+                      service: CinderPassword
+                      transportUrl: TransportURL
                     description: PasswordSelectors - Selectors to identify the DB
-                      and AdminUser password and TransportURL from the Secret
+                      and ServiceUser password and TransportURL from the Secret
                     properties:
-                      admin:
-                        default: CinderPassword
-                        description: Database - Selector to get the cinder service
-                          password from the Secret
-                        type: string
                       database:
                         default: CinderDatabasePassword
                         description: 'Database - Selector to get the cinder database
                           user password from the Secret TODO: not used, need change
                           in mariadb-operator'
+                        type: string
+                      service:
+                        default: CinderPassword
+                        description: Database - Selector to get the cinder service
+                          password from the Secret
                         type: string
                       transportUrl:
                         default: TransportURL
@@ -249,19 +253,23 @@ spec:
                       running the Backup service
                     type: object
                   passwordSelectors:
+                    default:
+                      database: CinderDatabasePassword
+                      service: CinderPassword
+                      transportUrl: TransportURL
                     description: PasswordSelectors - Selectors to identify the DB
-                      and TransportURL from the Secret
+                      and ServiceUser password and TransportURL from the Secret
                     properties:
-                      admin:
-                        default: CinderPassword
-                        description: Database - Selector to get the cinder service
-                          password from the Secret
-                        type: string
                       database:
                         default: CinderDatabasePassword
                         description: 'Database - Selector to get the cinder database
                           user password from the Secret TODO: not used, need change
                           in mariadb-operator'
+                        type: string
+                      service:
+                        default: CinderPassword
+                        description: Database - Selector to get the cinder service
+                          password from the Secret
                         type: string
                       transportUrl:
                         default: TransportURL
@@ -365,19 +373,23 @@ spec:
                       running the Scheduler service
                     type: object
                   passwordSelectors:
+                    default:
+                      database: CinderDatabasePassword
+                      service: CinderPassword
+                      transportUrl: TransportURL
                     description: PasswordSelectors - Selectors to identify the DB
-                      and TransportURL from the Secret
+                      and ServiceUser password and TransportURL from the Secret
                     properties:
-                      admin:
-                        default: CinderPassword
-                        description: Database - Selector to get the cinder service
-                          password from the Secret
-                        type: string
                       database:
                         default: CinderDatabasePassword
                         description: 'Database - Selector to get the cinder database
                           user password from the Secret TODO: not used, need change
                           in mariadb-operator'
+                        type: string
+                      service:
+                        default: CinderPassword
+                        description: Database - Selector to get the cinder service
+                          password from the Secret
                         type: string
                       transportUrl:
                         default: TransportURL
@@ -482,19 +494,23 @@ spec:
                         running the Volume service
                       type: object
                     passwordSelectors:
+                      default:
+                        database: CinderDatabasePassword
+                        service: CinderPassword
+                        transportUrl: TransportURL
                       description: PasswordSelectors - Selectors to identify the DB
-                        and TransportURL from the Secret
+                        and ServiceUser password and TransportURL from the Secret
                       properties:
-                        admin:
-                          default: CinderPassword
-                          description: Database - Selector to get the cinder service
-                            password from the Secret
-                          type: string
                         database:
                           default: CinderDatabasePassword
                           description: 'Database - Selector to get the cinder database
                             user password from the Secret TODO: not used, need change
                             in mariadb-operator'
+                          type: string
+                        service:
+                          default: CinderPassword
+                          description: Database - Selector to get the cinder service
+                            password from the Secret
                           type: string
                         transportUrl:
                           default: TransportURL
@@ -592,18 +608,22 @@ spec:
                   . TODO: -> implement'
                 type: object
               passwordSelectors:
+                default:
+                  database: CinderDatabasePassword
+                  service: CinderPassword
+                  transportUrl: TransportURL
                 description: PasswordSelectors - Selectors to identify the DB and
-                  AdminUser password and TransportURL from the Secret
+                  ServiceUser password and TransportURL from the Secret
                 properties:
-                  admin:
-                    default: CinderPassword
-                    description: Database - Selector to get the cinder service password
-                      from the Secret
-                    type: string
                   database:
                     default: CinderDatabasePassword
                     description: 'Database - Selector to get the cinder database user
                       password from the Secret TODO: not used, need change in mariadb-operator'
+                    type: string
+                  service:
+                    default: CinderPassword
+                    description: Database - Selector to get the cinder service password
+                      from the Secret
                     type: string
                   transportUrl:
                     default: TransportURL
@@ -618,7 +638,7 @@ spec:
                 type: boolean
               secret:
                 description: Secret containing OpenStack password information for
-                  CinderDatabasePassword, AdminPassword
+                  CinderDatabasePassword, CinderPassword
                 type: string
               serviceUser:
                 default: cinder

--- a/api/bases/cinder.openstack.org_cinderschedulers.yaml
+++ b/api/bases/cinder.openstack.org_cinderschedulers.yaml
@@ -85,18 +85,22 @@ spec:
                   the Scheduler service
                 type: object
               passwordSelectors:
+                default:
+                  database: CinderDatabasePassword
+                  service: CinderPassword
+                  transportUrl: TransportURL
                 description: PasswordSelectors - Selectors to identify the DB and
-                  TransportURL from the Secret
+                  ServiceUser password and TransportURL from the Secret
                 properties:
-                  admin:
-                    default: CinderPassword
-                    description: Database - Selector to get the cinder service password
-                      from the Secret
-                    type: string
                   database:
                     default: CinderDatabasePassword
                     description: 'Database - Selector to get the cinder database user
                       password from the Secret TODO: not used, need change in mariadb-operator'
+                    type: string
+                  service:
+                    default: CinderPassword
+                    description: Database - Selector to get the cinder service password
+                      from the Secret
                     type: string
                   transportUrl:
                     default: TransportURL

--- a/api/bases/cinder.openstack.org_cindervolumes.yaml
+++ b/api/bases/cinder.openstack.org_cindervolumes.yaml
@@ -85,18 +85,22 @@ spec:
                   the Volume service
                 type: object
               passwordSelectors:
+                default:
+                  database: CinderDatabasePassword
+                  service: CinderPassword
+                  transportUrl: TransportURL
                 description: PasswordSelectors - Selectors to identify the DB and
-                  TransportURL from the Secret
+                  ServiceUser password and TransportURL from the Secret
                 properties:
-                  admin:
-                    default: CinderPassword
-                    description: Database - Selector to get the cinder service password
-                      from the Secret
-                    type: string
                   database:
                     default: CinderDatabasePassword
                     description: 'Database - Selector to get the cinder database user
                       password from the Secret TODO: not used, need change in mariadb-operator'
+                    type: string
+                  service:
+                    default: CinderPassword
+                    description: Database - Selector to get the cinder service password
+                      from the Secret
                     type: string
                   transportUrl:
                     default: TransportURL

--- a/api/v1beta1/cinder_types.go
+++ b/api/v1beta1/cinder_types.go
@@ -50,11 +50,12 @@ type CinderSpec struct {
 	DatabaseUser string `json:"databaseUser"`
 
 	// +kubebuilder:validation:Required
-	// Secret containing OpenStack password information for CinderDatabasePassword, AdminPassword
+	// Secret containing OpenStack password information for CinderDatabasePassword, CinderPassword
 	Secret string `json:"secret,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// PasswordSelectors - Selectors to identify the DB and AdminUser password and TransportURL from the Secret
+	// +kubebuilder:default={database: CinderDatabasePassword, service: CinderPassword, transportUrl: TransportURL}
+	// PasswordSelectors - Selectors to identify the DB and ServiceUser password and TransportURL from the Secret
 	PasswordSelectors PasswordSelector `json:"passwordSelectors,omitempty"`
 
 	// +kubebuilder:validation:Optional

--- a/api/v1beta1/cinderapi_types.go
+++ b/api/v1beta1/cinderapi_types.go
@@ -53,7 +53,8 @@ type CinderAPISpec struct {
 	Secret string `json:"secret,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// PasswordSelectors - Selectors to identify the DB and AdminUser password and TransportURL from the Secret
+	// +kubebuilder:default={database: CinderDatabasePassword, service: CinderPassword, transportUrl: TransportURL}
+	// PasswordSelectors - Selectors to identify the DB and ServiceUser password and TransportURL from the Secret
 	PasswordSelectors PasswordSelector `json:"passwordSelectors,omitempty"`
 
 	// +kubebuilder:validation:Optional

--- a/api/v1beta1/cinderbackup_types.go
+++ b/api/v1beta1/cinderbackup_types.go
@@ -52,7 +52,8 @@ type CinderBackupSpec struct {
 	Secret string `json:"secret,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// PasswordSelectors - Selectors to identify the DB and TransportURL from the Secret
+	// +kubebuilder:default={database: CinderDatabasePassword, service: CinderPassword, transportUrl: TransportURL}
+	// PasswordSelectors - Selectors to identify the DB and ServiceUser password and TransportURL from the Secret
 	PasswordSelectors PasswordSelector `json:"passwordSelectors,omitempty"`
 
 	// +kubebuilder:validation:Optional

--- a/api/v1beta1/cinderscheduler_types.go
+++ b/api/v1beta1/cinderscheduler_types.go
@@ -53,7 +53,8 @@ type CinderSchedulerSpec struct {
 	Secret string `json:"secret,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// PasswordSelectors - Selectors to identify the DB and TransportURL from the Secret
+	// +kubebuilder:default={database: CinderDatabasePassword, service: CinderPassword, transportUrl: TransportURL}
+	// PasswordSelectors - Selectors to identify the DB and ServiceUser password and TransportURL from the Secret
 	PasswordSelectors PasswordSelector `json:"passwordSelectors,omitempty"`
 
 	// +kubebuilder:validation:Optional

--- a/api/v1beta1/cindervolume_types.go
+++ b/api/v1beta1/cindervolume_types.go
@@ -54,7 +54,8 @@ type CinderVolumeSpec struct {
 	Secret string `json:"secret,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// PasswordSelectors - Selectors to identify the DB and TransportURL from the Secret
+	// +kubebuilder:default={database: CinderDatabasePassword, service: CinderPassword, transportUrl: TransportURL}
+	// PasswordSelectors - Selectors to identify the DB and ServiceUser password and TransportURL from the Secret
 	PasswordSelectors PasswordSelector `json:"passwordSelectors,omitempty"`
 
 	// +kubebuilder:validation:Optional

--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -26,7 +26,7 @@ type PasswordSelector struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default="CinderPassword"
 	// Database - Selector to get the cinder service password from the Secret
-	Service string `json:"admin,omitempty"`
+	Service string `json:"service,omitempty"`
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default="TransportURL"
 	// Database - Selector to get the cinder service password from the Secret

--- a/config/crd/bases/cinder.openstack.org_cinderapis.yaml
+++ b/config/crd/bases/cinder.openstack.org_cinderapis.yaml
@@ -85,18 +85,22 @@ spec:
                   the API service
                 type: object
               passwordSelectors:
+                default:
+                  database: CinderDatabasePassword
+                  service: CinderPassword
+                  transportUrl: TransportURL
                 description: PasswordSelectors - Selectors to identify the DB and
-                  AdminUser password and TransportURL from the Secret
+                  ServiceUser password and TransportURL from the Secret
                 properties:
-                  admin:
-                    default: CinderPassword
-                    description: Database - Selector to get the cinder service password
-                      from the Secret
-                    type: string
                   database:
                     default: CinderDatabasePassword
                     description: 'Database - Selector to get the cinder database user
                       password from the Secret TODO: not used, need change in mariadb-operator'
+                    type: string
+                  service:
+                    default: CinderPassword
+                    description: Database - Selector to get the cinder service password
+                      from the Secret
                     type: string
                   transportUrl:
                     default: TransportURL

--- a/config/crd/bases/cinder.openstack.org_cinderbackups.yaml
+++ b/config/crd/bases/cinder.openstack.org_cinderbackups.yaml
@@ -85,18 +85,22 @@ spec:
                   the Backup service
                 type: object
               passwordSelectors:
+                default:
+                  database: CinderDatabasePassword
+                  service: CinderPassword
+                  transportUrl: TransportURL
                 description: PasswordSelectors - Selectors to identify the DB and
-                  TransportURL from the Secret
+                  ServiceUser password and TransportURL from the Secret
                 properties:
-                  admin:
-                    default: CinderPassword
-                    description: Database - Selector to get the cinder service password
-                      from the Secret
-                    type: string
                   database:
                     default: CinderDatabasePassword
                     description: 'Database - Selector to get the cinder database user
                       password from the Secret TODO: not used, need change in mariadb-operator'
+                    type: string
+                  service:
+                    default: CinderPassword
+                    description: Database - Selector to get the cinder service password
+                      from the Secret
                     type: string
                   transportUrl:
                     default: TransportURL

--- a/config/crd/bases/cinder.openstack.org_cinders.yaml
+++ b/config/crd/bases/cinder.openstack.org_cinders.yaml
@@ -133,19 +133,23 @@ spec:
                       running the API service
                     type: object
                   passwordSelectors:
+                    default:
+                      database: CinderDatabasePassword
+                      service: CinderPassword
+                      transportUrl: TransportURL
                     description: PasswordSelectors - Selectors to identify the DB
-                      and AdminUser password and TransportURL from the Secret
+                      and ServiceUser password and TransportURL from the Secret
                     properties:
-                      admin:
-                        default: CinderPassword
-                        description: Database - Selector to get the cinder service
-                          password from the Secret
-                        type: string
                       database:
                         default: CinderDatabasePassword
                         description: 'Database - Selector to get the cinder database
                           user password from the Secret TODO: not used, need change
                           in mariadb-operator'
+                        type: string
+                      service:
+                        default: CinderPassword
+                        description: Database - Selector to get the cinder service
+                          password from the Secret
                         type: string
                       transportUrl:
                         default: TransportURL
@@ -249,19 +253,23 @@ spec:
                       running the Backup service
                     type: object
                   passwordSelectors:
+                    default:
+                      database: CinderDatabasePassword
+                      service: CinderPassword
+                      transportUrl: TransportURL
                     description: PasswordSelectors - Selectors to identify the DB
-                      and TransportURL from the Secret
+                      and ServiceUser password and TransportURL from the Secret
                     properties:
-                      admin:
-                        default: CinderPassword
-                        description: Database - Selector to get the cinder service
-                          password from the Secret
-                        type: string
                       database:
                         default: CinderDatabasePassword
                         description: 'Database - Selector to get the cinder database
                           user password from the Secret TODO: not used, need change
                           in mariadb-operator'
+                        type: string
+                      service:
+                        default: CinderPassword
+                        description: Database - Selector to get the cinder service
+                          password from the Secret
                         type: string
                       transportUrl:
                         default: TransportURL
@@ -365,19 +373,23 @@ spec:
                       running the Scheduler service
                     type: object
                   passwordSelectors:
+                    default:
+                      database: CinderDatabasePassword
+                      service: CinderPassword
+                      transportUrl: TransportURL
                     description: PasswordSelectors - Selectors to identify the DB
-                      and TransportURL from the Secret
+                      and ServiceUser password and TransportURL from the Secret
                     properties:
-                      admin:
-                        default: CinderPassword
-                        description: Database - Selector to get the cinder service
-                          password from the Secret
-                        type: string
                       database:
                         default: CinderDatabasePassword
                         description: 'Database - Selector to get the cinder database
                           user password from the Secret TODO: not used, need change
                           in mariadb-operator'
+                        type: string
+                      service:
+                        default: CinderPassword
+                        description: Database - Selector to get the cinder service
+                          password from the Secret
                         type: string
                       transportUrl:
                         default: TransportURL
@@ -482,19 +494,23 @@ spec:
                         running the Volume service
                       type: object
                     passwordSelectors:
+                      default:
+                        database: CinderDatabasePassword
+                        service: CinderPassword
+                        transportUrl: TransportURL
                       description: PasswordSelectors - Selectors to identify the DB
-                        and TransportURL from the Secret
+                        and ServiceUser password and TransportURL from the Secret
                       properties:
-                        admin:
-                          default: CinderPassword
-                          description: Database - Selector to get the cinder service
-                            password from the Secret
-                          type: string
                         database:
                           default: CinderDatabasePassword
                           description: 'Database - Selector to get the cinder database
                             user password from the Secret TODO: not used, need change
                             in mariadb-operator'
+                          type: string
+                        service:
+                          default: CinderPassword
+                          description: Database - Selector to get the cinder service
+                            password from the Secret
                           type: string
                         transportUrl:
                           default: TransportURL
@@ -592,18 +608,22 @@ spec:
                   . TODO: -> implement'
                 type: object
               passwordSelectors:
+                default:
+                  database: CinderDatabasePassword
+                  service: CinderPassword
+                  transportUrl: TransportURL
                 description: PasswordSelectors - Selectors to identify the DB and
-                  AdminUser password and TransportURL from the Secret
+                  ServiceUser password and TransportURL from the Secret
                 properties:
-                  admin:
-                    default: CinderPassword
-                    description: Database - Selector to get the cinder service password
-                      from the Secret
-                    type: string
                   database:
                     default: CinderDatabasePassword
                     description: 'Database - Selector to get the cinder database user
                       password from the Secret TODO: not used, need change in mariadb-operator'
+                    type: string
+                  service:
+                    default: CinderPassword
+                    description: Database - Selector to get the cinder service password
+                      from the Secret
                     type: string
                   transportUrl:
                     default: TransportURL
@@ -618,7 +638,7 @@ spec:
                 type: boolean
               secret:
                 description: Secret containing OpenStack password information for
-                  CinderDatabasePassword, AdminPassword
+                  CinderDatabasePassword, CinderPassword
                 type: string
               serviceUser:
                 default: cinder

--- a/config/crd/bases/cinder.openstack.org_cinderschedulers.yaml
+++ b/config/crd/bases/cinder.openstack.org_cinderschedulers.yaml
@@ -85,18 +85,22 @@ spec:
                   the Scheduler service
                 type: object
               passwordSelectors:
+                default:
+                  database: CinderDatabasePassword
+                  service: CinderPassword
+                  transportUrl: TransportURL
                 description: PasswordSelectors - Selectors to identify the DB and
-                  TransportURL from the Secret
+                  ServiceUser password and TransportURL from the Secret
                 properties:
-                  admin:
-                    default: CinderPassword
-                    description: Database - Selector to get the cinder service password
-                      from the Secret
-                    type: string
                   database:
                     default: CinderDatabasePassword
                     description: 'Database - Selector to get the cinder database user
                       password from the Secret TODO: not used, need change in mariadb-operator'
+                    type: string
+                  service:
+                    default: CinderPassword
+                    description: Database - Selector to get the cinder service password
+                      from the Secret
                     type: string
                   transportUrl:
                     default: TransportURL

--- a/config/crd/bases/cinder.openstack.org_cindervolumes.yaml
+++ b/config/crd/bases/cinder.openstack.org_cindervolumes.yaml
@@ -85,18 +85,22 @@ spec:
                   the Volume service
                 type: object
               passwordSelectors:
+                default:
+                  database: CinderDatabasePassword
+                  service: CinderPassword
+                  transportUrl: TransportURL
                 description: PasswordSelectors - Selectors to identify the DB and
-                  TransportURL from the Secret
+                  ServiceUser password and TransportURL from the Secret
                 properties:
-                  admin:
-                    default: CinderPassword
-                    description: Database - Selector to get the cinder service password
-                      from the Secret
-                    type: string
                   database:
                     default: CinderDatabasePassword
                     description: 'Database - Selector to get the cinder database user
                       password from the Secret TODO: not used, need change in mariadb-operator'
+                    type: string
+                  service:
+                    default: CinderPassword
+                    description: Database - Selector to get the cinder service password
+                      from the Secret
                     type: string
                   transportUrl:
                     default: TransportURL


### PR DESCRIPTION
When a CRD has an optional struct field the defaulting of that field needs special care. Both the field with the struct type need a full default value defined and each individual subfields in the struct needs default value defined. Otherwise in the first reconcile call the PasswordSelectors is empty and then in the second reconcile it is filled.

Now documented via https://github.com/openstack-k8s-operators/docs/pull/12