### PR TITLE
Lint improvements

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -40,3 +40,16 @@ jobs:
         with:
           version: latest
           args: --timeout 5m
+
+  operator-lint:
+    name: operator-lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.18.x
+      - name: Checkout project code
+        uses: actions/checkout@v2
+      - name: Run operator-lint
+        run: make operator-lint

--- a/Makefile
+++ b/Makefile
@@ -120,14 +120,17 @@ fmt: ## Run go fmt against code.
 	go fmt ./...
 
 .PHONY: vet
+vet: export GOWORK=
 vet: ## Run go vet against code.
 	go vet ./... ./api/...
 
 .PHONY: test
+test: export GOWORK=
 test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... ./api/... -coverprofile cover.out
 
 .PHONY: gowork
+gowork: export GOWORK=
 gowork: ## Generate go.work file to support our multi module repository
 	test -f go.work || go work init
 	go work use .

--- a/Makefile
+++ b/Makefile
@@ -310,3 +310,8 @@ golint: get-ci-tools
 	PATH=$(GOBIN):$(PATH); $(CI_TOOLS_REPO_DIR)/test-runner/golint.sh
 	PATH=$(GOBIN):$(PATH); $(CI_TOOLS_REPO_DIR)/test-runner/golint.sh ./api
 
+.PHONY: operator-lint
+operator-lint: export GOWORK=
+operator-lint: gowork ## Runs operator-lint
+	GOBIN=$(LOCALBIN) go install github.com/gibizer/operator-lint@v0.1.0
+	go vet -vettool=$(LOCALBIN)/operator-lint ./... ./api/...

--- a/api/bases/cinder.openstack.org_cinders.yaml
+++ b/api/bases/cinder.openstack.org_cinders.yaml
@@ -639,7 +639,9 @@ spec:
             required:
             - cinderAPI
             - cinderScheduler
+            - databaseInstance
             - rabbitMqClusterName
+            - secret
             type: object
           status:
             description: CinderStatus defines the observed state of Cinder

--- a/api/v1beta1/cinder_types.go
+++ b/api/v1beta1/cinder_types.go
@@ -41,7 +41,7 @@ type CinderSpec struct {
 	// MariaDB instance name
 	// Right now required by the maridb-operator to get the credentials from the instance to create the DB
 	// Might not be required in future
-	DatabaseInstance string `json:"databaseInstance,omitempty"`
+	DatabaseInstance string `json:"databaseInstance"`
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=cinder
@@ -57,7 +57,7 @@ type CinderSpec struct {
 
 	// +kubebuilder:validation:Required
 	// Secret containing OpenStack password information for CinderDatabasePassword, CinderPassword
-	Secret string `json:"secret,omitempty"`
+	Secret string `json:"secret"`
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default={database: CinderDatabasePassword, service: CinderPassword}

--- a/config/crd/bases/cinder.openstack.org_cinders.yaml
+++ b/config/crd/bases/cinder.openstack.org_cinders.yaml
@@ -639,7 +639,9 @@ spec:
             required:
             - cinderAPI
             - cinderScheduler
+            - databaseInstance
             - rabbitMqClusterName
+            - secret
             type: object
           status:
             description: CinderStatus defines the observed state of Cinder


### PR DESCRIPTION
1. ensure that normal linting runs on the `api` module as well
2. introduce operator-lint [1] make target and run it in github workflow to check for operator development specific rule violations.
3. fix such violations

**Please note that this change makes Secret and DatabaseInstance Required while it was Optional before.**

[1] https://github.com/gibizer/operator-lint
