### PR TITLE
Logging: Use ISO8601 timestamps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ CI_TOOLS_REPO
 # generated workspace file
 go.work
 go.work.sum
+
+# Hack files that get modified
+hack/Dockerfile.devel

--- a/Makefile
+++ b/Makefile
@@ -154,6 +154,22 @@ ifeq ($(IMG), $(DEFAULT_IMG))
 endif
 	podman push --tls-verify=${VERIFY_TLS} ${IMG}
 
+# --- CINDER-OPERATOR EXTRA TARGETS
+.PHONY: run-dev
+run-dev: ## Run a controller from your host in development mode, only rebuilds if binary doesn't exist
+ifeq ($(shell test -e bin/manager || echo -n no),no)
+	make build
+endif
+	# if zap-level>=4 then the verbosity of client-go will be set to this level.
+	OPERATOR_TEMPLATES=$PWD/templates bin/manager --zap-devel --zap-time-encoding=iso8601 --zap-log-level=3 --zap-encoder=console
+
+.PHONY: docker-build-dev
+docker-build-dev: test ## Build docker image with the manager in development mode.
+	cp Dockerfile hack/Dockerfile.devel
+	echo 'CMD ["--zap-devel", "--zap-time-encoding=iso8601", "--zap-log-level=3", "--zap-encoder=console"]' >> hack/Dockerfile.devel
+	podman build -f hack/Dockerfile.devel -t ${IMG} .
+# --- END OF CINDER-OPERATOR EXTRA TARGETS
+
 ##@ Deployment
 
 ifndef ignore-not-found

--- a/main.go
+++ b/main.go
@@ -67,12 +67,10 @@ func main() {
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
-	opts := zap.Options{
-		Development: true,
-	}
+
+	opts := zap.Options{}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
-
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{


### PR DESCRIPTION
This patch disables the zap development logging mode that was the
default in the Cinder operator.

The new code does not set any zap options and only expects to read
options from the command line.

For development purposes it is convenient to run logging not only in
development mode, but also increase the log levels and change the time
encoding from epoc to iso8601 which is easier to read for humans, so 2
new make targets are added, `run-dev` and `docker-build-dev` which are
similar to the `run` and `docker-build` targets.

The `run-dev` target is different from the standard `run` because it
will only build the operator if the binary doesn't exist.