### PR TITLE
Makefile: Fix install and deploy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ help: ## Display this help.
 
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases && \
+	$(CONTROLLER_GEN) rbac:roleName=manager-role crd$(CRDDESC_OVERRIDE) webhook paths="./..." output:crd:artifacts:config=config/crd/bases && \
 	rm -f api/bases/* && cp -a config/crd/bases api/
 
 
@@ -151,6 +151,7 @@ ifndef ignore-not-found
 endif
 
 .PHONY: install
+install: CRDDESC_OVERRIDE=:maxDescLen=0
 install: manifests kustomize ## Install CRDs and RBAC into the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE) build config/dev | kubectl apply -f -
 
@@ -159,6 +160,7 @@ uninstall: manifests kustomize ## Uninstall CRDs and RBAC from the K8s cluster s
 	$(KUSTOMIZE) build config/dev | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
 
 .PHONY: deploy
+deploy: CRDDESC_OVERRIDE=:maxDescLen=0
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	$(KUSTOMIZE) build config/default | kubectl apply -f -


### PR DESCRIPTION
When installing CRDs in the cluster it will fail due to the length of the CRD.

  The CustomResourceDefinition "cinders.cinder.openstack.org" is
  invalid: metadata.annotations: Too long: must have at most 262144
  bytes

To fix this we'll remove the descriptions on the CRDs when running `install` and `deploy` targets.

This is done with `crd:maxDescLen=0` just like it has been done in the openstack-operator.

We didn't use to have this size problem, but now we do with the addition of the `extraVol`.