### PR TITLE
Add top level NodeSelector to Cinder CR

### DIFF
--- a/api/bases/cinder.openstack.org_cinderapis.yaml
+++ b/api/bases/cinder.openstack.org_cinderapis.yaml
@@ -1885,8 +1885,9 @@ spec:
               nodeSelector:
                 additionalProperties:
                   type: string
-                description: NodeSelector to target subset of worker nodes for running
-                  the API service
+                description: NodeSelector to target subset of worker nodes running
+                  this service. Setting here overrides any global NodeSelector settings
+                  within the Cinder CR.
                 type: object
               passwordSelectors:
                 default:

--- a/api/bases/cinder.openstack.org_cinders.yaml
+++ b/api/bases/cinder.openstack.org_cinders.yaml
@@ -2005,8 +2005,9 @@ spec:
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: NodeSelector to target subset of worker nodes for
-                      running the API service
+                    description: NodeSelector to target subset of worker nodes running
+                      this service. Setting here overrides any global NodeSelector
+                      settings within the Cinder CR.
                     type: object
                   passwordSelectors:
                     default:
@@ -6061,8 +6062,9 @@ spec:
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: NodeSelector to target subset of worker nodes for
-                      running the Scheduler service
+                    description: NodeSelector to target subset of worker nodes running
+                      this service. Setting here overrides any global NodeSelector
+                      settings within the Cinder CR.
                     type: object
                   passwordSelectors:
                     default:
@@ -8138,8 +8140,9 @@ spec:
                     nodeSelector:
                       additionalProperties:
                         type: string
-                      description: NodeSelector to target subset of worker nodes for
-                        running the Volume service
+                      description: NodeSelector to target subset of worker nodes running
+                        this service. Setting here overrides any global NodeSelector
+                        settings within the Cinder CR.
                       type: object
                     passwordSelectors:
                       default:
@@ -10055,6 +10058,13 @@ spec:
                   - extraVol
                   type: object
                 type: array
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: NodeSelector to target subset of worker nodes running
+                  this service. Setting NodeSelector here acts as a default value
+                  and can be overridden by service specific NodeSelector Settings.
+                type: object
               passwordSelectors:
                 default:
                   database: CinderDatabasePassword

--- a/api/bases/cinder.openstack.org_cinderschedulers.yaml
+++ b/api/bases/cinder.openstack.org_cinderschedulers.yaml
@@ -1885,8 +1885,9 @@ spec:
               nodeSelector:
                 additionalProperties:
                   type: string
-                description: NodeSelector to target subset of worker nodes for running
-                  the Scheduler service
+                description: NodeSelector to target subset of worker nodes running
+                  this service. Setting here overrides any global NodeSelector settings
+                  within the Cinder CR.
                 type: object
               passwordSelectors:
                 default:

--- a/api/bases/cinder.openstack.org_cindervolumes.yaml
+++ b/api/bases/cinder.openstack.org_cindervolumes.yaml
@@ -1885,8 +1885,9 @@ spec:
               nodeSelector:
                 additionalProperties:
                   type: string
-                description: NodeSelector to target subset of worker nodes for running
-                  the Volume service
+                description: NodeSelector to target subset of worker nodes running
+                  this service. Setting here overrides any global NodeSelector settings
+                  within the Cinder CR.
                 type: object
               passwordSelectors:
                 default:

--- a/api/v1beta1/cinder_types.go
+++ b/api/v1beta1/cinder_types.go
@@ -18,8 +18,8 @@ package v1beta1
 
 import (
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"github.com/openstack-k8s-operators/lib-common/modules/storage"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -119,6 +119,12 @@ type CinderSpec struct {
 	// +kubebuilder:validation:Optional
 	// ExtraMounts containing conf files and credentials
 	ExtraMounts []CinderExtraVolMounts `json:"extraMounts"`
+
+	// +kubebuilder:validation:Optional
+	// NodeSelector to target subset of worker nodes running this service. Setting
+	// NodeSelector here acts as a default value and can be overridden by service
+	// specific NodeSelector Settings.
+	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 }
 
 // CinderStatus defines the observed state of Cinder

--- a/api/v1beta1/cinderapi_types.go
+++ b/api/v1beta1/cinderapi_types.go
@@ -63,7 +63,8 @@ type CinderAPISpec struct {
 	PasswordSelectors PasswordSelector `json:"passwordSelectors,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// NodeSelector to target subset of worker nodes for running the API service
+	// NodeSelector to target subset of worker nodes running this service. Setting here overrides
+	// any global NodeSelector settings within the Cinder CR.
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 
 	// +kubebuilder:validation:Optional

--- a/api/v1beta1/cinderscheduler_types.go
+++ b/api/v1beta1/cinderscheduler_types.go
@@ -63,7 +63,8 @@ type CinderSchedulerSpec struct {
 	PasswordSelectors PasswordSelector `json:"passwordSelectors,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// NodeSelector to target subset of worker nodes for running the Scheduler service
+	// NodeSelector to target subset of worker nodes running this service. Setting here overrides
+	// any global NodeSelector settings within the Cinder CR.
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 
 	// +kubebuilder:validation:Optional

--- a/api/v1beta1/cindervolume_types.go
+++ b/api/v1beta1/cindervolume_types.go
@@ -64,7 +64,8 @@ type CinderVolumeSpec struct {
 	PasswordSelectors PasswordSelector `json:"passwordSelectors,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// NodeSelector to target subset of worker nodes for running the Volume service
+	// NodeSelector to target subset of worker nodes running this service. Setting here overrides
+	// any global NodeSelector settings within the Cinder CR.
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 
 	// +kubebuilder:validation:Optional

--- a/config/crd/bases/cinder.openstack.org_cinderapis.yaml
+++ b/config/crd/bases/cinder.openstack.org_cinderapis.yaml
@@ -1885,8 +1885,9 @@ spec:
               nodeSelector:
                 additionalProperties:
                   type: string
-                description: NodeSelector to target subset of worker nodes for running
-                  the API service
+                description: NodeSelector to target subset of worker nodes running
+                  this service. Setting here overrides any global NodeSelector settings
+                  within the Cinder CR.
                 type: object
               passwordSelectors:
                 default:

--- a/config/crd/bases/cinder.openstack.org_cinders.yaml
+++ b/config/crd/bases/cinder.openstack.org_cinders.yaml
@@ -2005,8 +2005,9 @@ spec:
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: NodeSelector to target subset of worker nodes for
-                      running the API service
+                    description: NodeSelector to target subset of worker nodes running
+                      this service. Setting here overrides any global NodeSelector
+                      settings within the Cinder CR.
                     type: object
                   passwordSelectors:
                     default:
@@ -6061,8 +6062,9 @@ spec:
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: NodeSelector to target subset of worker nodes for
-                      running the Scheduler service
+                    description: NodeSelector to target subset of worker nodes running
+                      this service. Setting here overrides any global NodeSelector
+                      settings within the Cinder CR.
                     type: object
                   passwordSelectors:
                     default:
@@ -8138,8 +8140,9 @@ spec:
                     nodeSelector:
                       additionalProperties:
                         type: string
-                      description: NodeSelector to target subset of worker nodes for
-                        running the Volume service
+                      description: NodeSelector to target subset of worker nodes running
+                        this service. Setting here overrides any global NodeSelector
+                        settings within the Cinder CR.
                       type: object
                     passwordSelectors:
                       default:
@@ -10055,6 +10058,13 @@ spec:
                   - extraVol
                   type: object
                 type: array
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: NodeSelector to target subset of worker nodes running
+                  this service. Setting NodeSelector here acts as a default value
+                  and can be overridden by service specific NodeSelector Settings.
+                type: object
               passwordSelectors:
                 default:
                   database: CinderDatabasePassword

--- a/config/crd/bases/cinder.openstack.org_cinderschedulers.yaml
+++ b/config/crd/bases/cinder.openstack.org_cinderschedulers.yaml
@@ -1885,8 +1885,9 @@ spec:
               nodeSelector:
                 additionalProperties:
                   type: string
-                description: NodeSelector to target subset of worker nodes for running
-                  the Scheduler service
+                description: NodeSelector to target subset of worker nodes running
+                  this service. Setting here overrides any global NodeSelector settings
+                  within the Cinder CR.
                 type: object
               passwordSelectors:
                 default:

--- a/config/crd/bases/cinder.openstack.org_cindervolumes.yaml
+++ b/config/crd/bases/cinder.openstack.org_cindervolumes.yaml
@@ -1885,8 +1885,9 @@ spec:
               nodeSelector:
                 additionalProperties:
                   type: string
-                description: NodeSelector to target subset of worker nodes for running
-                  the Volume service
+                description: NodeSelector to target subset of worker nodes running
+                  this service. Setting here overrides any global NodeSelector settings
+                  within the Cinder CR.
                 type: object
               passwordSelectors:
                 default:

--- a/controllers/cinder_controller.go
+++ b/controllers/cinder_controller.go
@@ -635,10 +635,8 @@ func (r *CinderReconciler) reconcileUpgrade(ctx context.Context, instance *cinde
 	return ctrl.Result{}, nil
 }
 
-//
 // generateServiceConfigMaps - create create configmaps which hold scripts and service configuration
 // TODO add DefaultConfigOverwrite
-//
 func (r *CinderReconciler) generateServiceConfigMaps(
 	ctx context.Context,
 	h *helper.Helper,
@@ -706,10 +704,8 @@ func (r *CinderReconciler) generateServiceConfigMaps(
 	return nil
 }
 
-//
 // createHashOfInputHashes - creates a hash of hashes which gets added to the resources which requires a restart
 // if any of the input resources change, like configs, passwords, ...
-//
 func (r *CinderReconciler) createHashOfInputHashes(
 	ctx context.Context,
 	instance *cinderv1beta1.Cinder,
@@ -766,6 +762,9 @@ func (r *CinderReconciler) apiDeploymentCreateOrUpdate(instance *cinderv1beta1.C
 		deployment.Spec.Secret = instance.Spec.Secret
 		deployment.Spec.TransportURLSecret = instance.Status.TransportURLSecret
 		deployment.Spec.ExtraMounts = instance.Spec.ExtraMounts
+		if len(deployment.Spec.NodeSelector) == 0 {
+			deployment.Spec.NodeSelector = instance.Spec.NodeSelector
+		}
 
 		err := controllerutil.SetControllerReference(instance, deployment, r.Scheme)
 		if err != nil {
@@ -796,6 +795,9 @@ func (r *CinderReconciler) schedulerDeploymentCreateOrUpdate(instance *cinderv1b
 		deployment.Spec.Secret = instance.Spec.Secret
 		deployment.Spec.TransportURLSecret = instance.Status.TransportURLSecret
 		deployment.Spec.ExtraMounts = instance.Spec.ExtraMounts
+		if len(deployment.Spec.NodeSelector) == 0 {
+			deployment.Spec.NodeSelector = instance.Spec.NodeSelector
+		}
 
 		err := controllerutil.SetControllerReference(instance, deployment, r.Scheme)
 		if err != nil {
@@ -826,6 +828,9 @@ func (r *CinderReconciler) backupDeploymentCreateOrUpdate(instance *cinderv1beta
 		deployment.Spec.Secret = instance.Spec.Secret
 		deployment.Spec.TransportURLSecret = instance.Status.TransportURLSecret
 		deployment.Spec.ExtraMounts = instance.Spec.ExtraMounts
+		if len(deployment.Spec.NodeSelector) == 0 {
+			deployment.Spec.NodeSelector = instance.Spec.NodeSelector
+		}
 
 		err := controllerutil.SetControllerReference(instance, deployment, r.Scheme)
 		if err != nil {
@@ -856,6 +861,9 @@ func (r *CinderReconciler) volumeDeploymentCreateOrUpdate(instance *cinderv1beta
 		deployment.Spec.Secret = instance.Spec.Secret
 		deployment.Spec.TransportURLSecret = instance.Status.TransportURLSecret
 		deployment.Spec.ExtraMounts = instance.Spec.ExtraMounts
+		if len(deployment.Spec.NodeSelector) == 0 {
+			deployment.Spec.NodeSelector = instance.Spec.NodeSelector
+		}
 
 		err := controllerutil.SetControllerReference(instance, deployment, r.Scheme)
 		if err != nil {


### PR DESCRIPTION
This change adds the top level NodeSelecter to the Cinder CR.  This can then be overridden by individual CR's as required.