### PR TITLE
Remove useless GetVolumes call

### DIFF
--- a/pkg/cinder/dbsync.go
+++ b/pkg/cinder/dbsync.go
@@ -66,8 +66,6 @@ func DbSyncJob(instance *cinderv1beta1.Cinder, labels map[string]string) *batchv
 		},
 	}
 
-	job.Spec.Template.Spec.Volumes = GetVolumes(ServiceName, false, dbSyncExtraMounts, DbsyncPropagation)
-
 	initContainerDetails := APIDetails{
 		ContainerImage:       instance.Spec.CinderAPI.ContainerImage,
 		DatabaseHost:         instance.Status.DatabaseHostname,


### PR DESCRIPTION
When `dbsync` is called, both `Volumes` and `VolumeMounts` are defined in the `DbSyncJob` function (using the very same parameters). 
This change just removes the duplicated line that calls the same function.

Signed-off-by: Francesco Pantano <fpantano@redhat.com>