### PR TITLE
Fix keystone services and endpoints

### DIFF
--- a/pkg/cinder/const.go
+++ b/pkg/cinder/const.go
@@ -22,16 +22,12 @@ import (
 const (
 	// ServiceName -
 	ServiceName = "cinder"
-	// ServiceNameV2 -
-	ServiceNameV2 = "cinderv2"
 	// ServiceNameV3 -
 	ServiceNameV3 = "cinderv3"
 	// ServiceType -
 	ServiceType = "cinder"
 	// ServiceAccount -
 	ServiceAccount = "cinder-operator-cinder"
-	// ServiceTypeV2 -
-	ServiceTypeV2 = "volumev2"
 	// ServiceTypeV3 -
 	ServiceTypeV3 = "volumev3"
 	// DatabaseName -


### PR DESCRIPTION
Remove the cinderv2 keystone service and endpoints. Cinder's APIv2 was removed in Xena.

The cinderv3 endpoints are updated to remove the project_id from the API URLs. Cinder no longer requires a project_id in the URL as of the Yoga release.

NOTE: This patch does not remove stale cinderv2 artifacts from an existing deployment. Due to another issue with the finalizers (to be addressed separately), the following commands can be executed to remove the v2 service and endpoints:

$ oc patch keystoneservice/cinderv2 --type json \
  --patch='[ { "op": "remove", "path": "/metadata/finalizers" } ]'
$ oc delete keystoneservice/cinderv2

$ oc patch keystoneendpoints/cinderv2 --type json \
  --patch='[ { "op": "remove", "path": "/metadata/finalizers" } ]'
$ oc delete keystoneendpoints/cinderv2