### PR TITLE
Use internal endpoint to interact with Keystone/Nova

### DIFF
--- a/controllers/cinder_controller.go
+++ b/controllers/cinder_controller.go
@@ -666,13 +666,18 @@ func (r *CinderReconciler) generateServiceConfigMaps(
 	if err != nil {
 		return err
 	}
-	authURL, err := keystoneAPI.GetEndpoint(endpoint.EndpointPublic)
+	keystoneInternalURL, err := keystoneAPI.GetEndpoint(endpoint.EndpointInternal)
+	if err != nil {
+		return err
+	}
+	keystonePublicURL, err := keystoneAPI.GetEndpoint(endpoint.EndpointPublic)
 	if err != nil {
 		return err
 	}
 	templateParameters := make(map[string]interface{})
 	templateParameters["ServiceUser"] = instance.Spec.ServiceUser
-	templateParameters["KeystonePublicURL"] = authURL
+	templateParameters["KeystoneInternalURL"] = keystoneInternalURL
+	templateParameters["KeystonePublicURL"] = keystonePublicURL
 
 	cms := []util.Template{
 		// ScriptsConfigMap

--- a/templates/cinder/config/cinder.conf
+++ b/templates/cinder/config/cinder.conf
@@ -50,7 +50,7 @@ enable_proxy_headers_parsing=True
 
 [keystone_authtoken]
 www_authenticate_uri={{ .KeystonePublicURL }}
-auth_url={{ .KeystonePublicURL }}
+auth_url = {{ .KeystoneInternalURL }}
 # TODO (mschuppert): Add memcached
 #memcached_servers = controller:11211
 auth_type = password
@@ -59,11 +59,12 @@ user_domain_name = Default
 project_name = service
 username = {{ .ServiceUser }}
 #service_token_roles_required = true
+interface = internal
 
 [nova]
-interface = admin
+interface = internal
 auth_type = password
-auth_url = {{ .KeystonePublicURL }}
+auth_url = {{ .KeystoneInternalURL }}
 #TODO: username
 username = nova
 user_domain_name = Default


### PR DESCRIPTION
Internal endpoint is meant for interaction between services. This ensures cinder uses internal endpoints when it sends requests to the other services.