### PR TITLE
Default CinderVolume and CinderBackup replicas to 0

### DIFF
--- a/api/bases/cinder.openstack.org_cinderbackups.yaml
+++ b/api/bases/cinder.openstack.org_cinderbackups.yaml
@@ -1907,6 +1907,7 @@ spec:
                     type: string
                 type: object
               replicas:
+                default: 0
                 description: Replicas - Cinder Backup Replicas
                 format: int32
                 type: integer

--- a/api/bases/cinder.openstack.org_cinders.yaml
+++ b/api/bases/cinder.openstack.org_cinders.yaml
@@ -4056,6 +4056,7 @@ spec:
                         type: string
                     type: object
                   replicas:
+                    default: 0
                     description: Replicas - Cinder Backup Replicas
                     format: int32
                     type: integer
@@ -8161,7 +8162,7 @@ spec:
                           type: string
                       type: object
                     replicas:
-                      default: 1
+                      default: 0
                       description: Replicas - Cinder Volume Replicas
                       format: int32
                       maximum: 1

--- a/api/bases/cinder.openstack.org_cindervolumes.yaml
+++ b/api/bases/cinder.openstack.org_cindervolumes.yaml
@@ -1907,7 +1907,7 @@ spec:
                     type: string
                 type: object
               replicas:
-                default: 1
+                default: 0
                 description: Replicas - Cinder Volume Replicas
                 format: int32
                 maximum: 1

--- a/api/v1beta1/cinderbackup_types.go
+++ b/api/v1beta1/cinderbackup_types.go
@@ -35,6 +35,7 @@ type CinderBackupSpec struct {
 	ContainerImage string `json:"containerImage,omitempty"`
 
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=0
 	// Replicas - Cinder Backup Replicas
 	Replicas int32 `json:"replicas"`
 
@@ -132,5 +133,5 @@ func init() {
 
 // IsReady - returns true if service is ready to serve requests
 func (instance CinderBackup) IsReady() bool {
-	return instance.Status.ReadyCount >= 1
+	return instance.Status.ReadyCount >= 1 || instance.Spec.Replicas == 0
 }

--- a/api/v1beta1/cindervolume_types.go
+++ b/api/v1beta1/cindervolume_types.go
@@ -35,7 +35,7 @@ type CinderVolumeSpec struct {
 	ContainerImage string `json:"containerImage,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default=1
+	// +kubebuilder:default=0
 	// +kubebuilder:validation:Maximum=1
 	// Replicas - Cinder Volume Replicas
 	Replicas int32 `json:"replicas"`
@@ -134,5 +134,5 @@ func init() {
 
 // IsReady - returns true if service is ready to serve requests
 func (instance CinderVolume) IsReady() bool {
-	return instance.Status.ReadyCount >= 1
+	return instance.Status.ReadyCount >= 1 || instance.Spec.Replicas == 0
 }

--- a/config/crd/bases/cinder.openstack.org_cinderbackups.yaml
+++ b/config/crd/bases/cinder.openstack.org_cinderbackups.yaml
@@ -1907,6 +1907,7 @@ spec:
                     type: string
                 type: object
               replicas:
+                default: 0
                 description: Replicas - Cinder Backup Replicas
                 format: int32
                 type: integer

--- a/config/crd/bases/cinder.openstack.org_cinders.yaml
+++ b/config/crd/bases/cinder.openstack.org_cinders.yaml
@@ -4056,6 +4056,7 @@ spec:
                         type: string
                     type: object
                   replicas:
+                    default: 0
                     description: Replicas - Cinder Backup Replicas
                     format: int32
                     type: integer
@@ -8161,7 +8162,7 @@ spec:
                           type: string
                       type: object
                     replicas:
-                      default: 1
+                      default: 0
                       description: Replicas - Cinder Volume Replicas
                       format: int32
                       maximum: 1

--- a/config/crd/bases/cinder.openstack.org_cindervolumes.yaml
+++ b/config/crd/bases/cinder.openstack.org_cindervolumes.yaml
@@ -1907,7 +1907,7 @@ spec:
                     type: string
                 type: object
               replicas:
-                default: 1
+                default: 0
                 description: Replicas - Cinder Volume Replicas
                 format: int32
                 maximum: 1


### PR DESCRIPTION
This patch changes the `CRD` default for both `CinderVolume` and `CinderBackup` replicas, setting it to `0`.
In addition, we need to make sure the `IsReady` returns `true` if no instances are defined.

Signed-off-by: Francesco Pantano <fpantano@redhat.com>