### PR TITLE
Use own user to send admin requests to nova

### DIFF
--- a/templates/cinder/bin/init.sh
+++ b/templates/cinder/bin/init.sh
@@ -23,9 +23,7 @@ export DB=${DatabaseName:-"cinder"}
 export DBHOST=${DatabaseHost:?"Please specify a DatabaseHost variable."}
 export DBUSER=${DatabaseUser:-"cinder"}
 export DBPASSWORD=${DatabasePassword:?"Please specify a DatabasePassword variable."}
-export CINDERPASSWORD=${CinderPassword:?"Please specify a CinderPassword variable."}
-# TODO: nova password
-#export NOVAPASSWORD=${NovaPassword:?"Please specify a NovaPassword variable."}
+export PASSWORD=${CinderPassword:?"Please specify a CinderPassword variable."}
 export TRANSPORTURL=${TransportURL:-""}
 
 export CUSTOMCONF=${CustomConf:-""}
@@ -73,8 +71,7 @@ if [ -n "$TRANSPORTURL" ]; then
   crudini --set ${SVC_CFG_MERGED} DEFAULT transport_url $TRANSPORTURL
 fi
 crudini --set ${SVC_CFG_MERGED} database connection mysql+pymysql://${DBUSER}:${DBPASSWORD}@${DBHOST}/${DB}
-crudini --set ${SVC_CFG_MERGED} keystone_authtoken password $CINDERPASSWORD
-# TODO: nova password
-#crudini --set ${SVC_CFG_MERGED} nova password $NOVAPASSWORD
+crudini --set ${SVC_CFG_MERGED} keystone_authtoken password $PASSWORD
+crudini --set ${SVC_CFG_MERGED} nova password $PASSWORD
 # TODO: service token
 #crudini --set ${SVC_CFG_MERGED} service_user password $CinderPassword

--- a/templates/cinder/config/cinder.conf
+++ b/templates/cinder/config/cinder.conf
@@ -65,8 +65,7 @@ interface = internal
 interface = internal
 auth_type = password
 auth_url = {{ .KeystoneInternalURL }}
-#TODO: username
-username = nova
+username = {{ . ServiceUser }}
 user_domain_name = Default
 project_name = service
 project_domain_name = Default


### PR DESCRIPTION
... instead of nova user. This allows us to reduce dependency on the resources managed by nova-operator and better separate each operators. The credential should work fine as long as the user has admin access with the 'service' project scope.