### PR TITLE
Add omitempty to CinderVolumeSpec

### DIFF
--- a/api/v1beta1/cinder_types.go
+++ b/api/v1beta1/cinder_types.go
@@ -114,7 +114,7 @@ type CinderSpec struct {
 
 	// +kubebuilder:validation:Optional
 	// CinderVolumes - Map of chosen names to spec definitions for the Volume(s) service(s) of this Cinder deployment
-	CinderVolumes map[string]CinderVolumeSpec `json:"cinderVolumes"`
+	CinderVolumes map[string]CinderVolumeSpec `json:"cinderVolumes,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// ExtraMounts containing conf files and credentials


### PR DESCRIPTION
deploy openstackcontrolplane without cinder specified fails right now with:

spec.cinder.template.cinderVolumes: Invalid value: "null": spec.cinder.template.cinderVolumes in body must be of type object: "null"