### PR TITLE
Bump operator-lint to 0.3.0 and fix findings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -331,5 +331,5 @@ golint: get-ci-tools
 .PHONY: operator-lint
 operator-lint: export GOWORK=
 operator-lint: $(LOCALBIN) gowork
-	GOBIN=$(LOCALBIN) go install github.com/gibizer/operator-lint@v0.2.1
+	GOBIN=$(LOCALBIN) go install github.com/gibizer/operator-lint@v0.3.0
 	go vet -vettool=$(LOCALBIN)/operator-lint ./... ./api/...

--- a/Makefile
+++ b/Makefile
@@ -329,6 +329,7 @@ golint: get-ci-tools
 	PATH=$(GOBIN):$(PATH); $(CI_TOOLS_REPO_DIR)/test-runner/golint.sh ./api
 
 .PHONY: operator-lint
+operator-lint: export GOWORK=
 operator-lint: $(LOCALBIN) gowork
-	GOBIN=$(LOCALBIN) go install github.com/gibizer/operator-lint@2ffa25b7f1c13fb2bdae5444a3dd1b5bbad5
+	GOBIN=$(LOCALBIN) go install github.com/gibizer/operator-lint@v0.2.1
 	go vet -vettool=$(LOCALBIN)/operator-lint ./... ./api/...

--- a/api/bases/cinder.openstack.org_cinderapis.yaml
+++ b/api/bases/cinder.openstack.org_cinderapis.yaml
@@ -43,7 +43,6 @@ spec:
               containerImage:
                 type: string
               customServiceConfig:
-                default: '# add your customization here'
                 type: string
               databaseHostname:
                 type: string

--- a/api/bases/cinder.openstack.org_cinderbackups.yaml
+++ b/api/bases/cinder.openstack.org_cinderbackups.yaml
@@ -43,7 +43,6 @@ spec:
               containerImage:
                 type: string
               customServiceConfig:
-                default: '# add your customization here'
                 type: string
               databaseHostname:
                 type: string

--- a/api/bases/cinder.openstack.org_cinders.yaml
+++ b/api/bases/cinder.openstack.org_cinders.yaml
@@ -41,7 +41,6 @@ spec:
                   containerImage:
                     type: string
                   customServiceConfig:
-                    default: '# add your customization here'
                     type: string
                   databaseHostname:
                     type: string
@@ -913,7 +912,6 @@ spec:
                   containerImage:
                     type: string
                   customServiceConfig:
-                    default: '# add your customization here'
                     type: string
                   databaseHostname:
                     type: string
@@ -1758,7 +1756,6 @@ spec:
                   containerImage:
                     type: string
                   customServiceConfig:
-                    default: '# add your customization here'
                     type: string
                   databaseHostname:
                     type: string
@@ -2605,7 +2602,6 @@ spec:
                     containerImage:
                       type: string
                     customServiceConfig:
-                      default: '# add your customization here'
                       type: string
                     databaseHostname:
                       type: string
@@ -3449,7 +3445,6 @@ spec:
                   type: object
                 type: object
               customServiceConfig:
-                default: '# add your customization here'
                 type: string
               databaseInstance:
                 type: string
@@ -4255,7 +4250,9 @@ spec:
             required:
             - cinderAPI
             - cinderScheduler
+            - databaseInstance
             - rabbitMqClusterName
+            - secret
             type: object
           status:
             properties:

--- a/api/bases/cinder.openstack.org_cinderschedulers.yaml
+++ b/api/bases/cinder.openstack.org_cinderschedulers.yaml
@@ -43,7 +43,6 @@ spec:
               containerImage:
                 type: string
               customServiceConfig:
-                default: '# add your customization here'
                 type: string
               databaseHostname:
                 type: string

--- a/api/bases/cinder.openstack.org_cindervolumes.yaml
+++ b/api/bases/cinder.openstack.org_cindervolumes.yaml
@@ -43,7 +43,6 @@ spec:
               containerImage:
                 type: string
               customServiceConfig:
-                default: '# add your customization here'
                 type: string
               databaseHostname:
                 type: string

--- a/api/v1beta1/cinder_types.go
+++ b/api/v1beta1/cinder_types.go
@@ -62,7 +62,7 @@ type CinderSpec struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default={database: CinderDatabasePassword, service: CinderPassword}
 	// PasswordSelectors - Selectors to identify the DB and ServiceUser password from the Secret
-	PasswordSelectors PasswordSelector `json:"passwordSelectors,omitempty"`
+	PasswordSelectors PasswordSelector `json:"passwordSelectors"`
 
 	// +kubebuilder:validation:Optional
 	// Debug - enable debug for different deploy stages. If an init container is used, it runs and the
@@ -72,10 +72,9 @@ type CinderSpec struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=false
 	// PreserveJobs - do not delete jobs after they finished e.g. to check logs
-	PreserveJobs bool `json:"preserveJobs,omitempty"`
+	PreserveJobs bool `json:"preserveJobs"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="# add your customization here"
 	// CustomServiceConfig - customize the service config for all Cinder services using this parameter to change service defaults,
 	// or overwrite rendered information using raw OpenStack config format. The content gets added to
 	// to /etc/<service>/<service>.conf.d directory as custom.conf file.

--- a/api/v1beta1/cinder_types.go
+++ b/api/v1beta1/cinder_types.go
@@ -41,7 +41,7 @@ type CinderSpec struct {
 	// MariaDB instance name
 	// Right now required by the maridb-operator to get the credentials from the instance to create the DB
 	// Might not be required in future
-	DatabaseInstance string `json:"databaseInstance,omitempty"`
+	DatabaseInstance string `json:"databaseInstance"`
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=cinder
@@ -57,7 +57,7 @@ type CinderSpec struct {
 
 	// +kubebuilder:validation:Required
 	// Secret containing OpenStack password information for CinderDatabasePassword, CinderPassword
-	Secret string `json:"secret,omitempty"`
+	Secret string `json:"secret"`
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default={database: CinderDatabasePassword, service: CinderPassword}

--- a/api/v1beta1/cinderapi_types.go
+++ b/api/v1beta1/cinderapi_types.go
@@ -46,7 +46,7 @@ type CinderAPISpec struct {
 	// +kubebuilder:default=cinder
 	// DatabaseUser - optional username used for cinder DB, defaults to cinder
 	// TODO: -> implement needs work in mariadb-operator, right now only cinder
-	DatabaseUser string `json:"databaseUser,omitempty"`
+	DatabaseUser string `json:"databaseUser"`
 
 	// +kubebuilder:validation:Optional
 	// Secret containing OpenStack password information for CinderDatabasePassword, AdminPassword
@@ -59,7 +59,7 @@ type CinderAPISpec struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default={database: CinderDatabasePassword, service: CinderPassword}
 	// PasswordSelectors - Selectors to identify the DB and ServiceUser password from the Secret
-	PasswordSelectors PasswordSelector `json:"passwordSelectors,omitempty"`
+	PasswordSelectors PasswordSelector `json:"passwordSelectors"`
 
 	// +kubebuilder:validation:Optional
 	// NodeSelector to target subset of worker nodes running this service. Setting here overrides
@@ -72,7 +72,6 @@ type CinderAPISpec struct {
 	Debug CinderServiceDebug `json:"debug,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="# add your customization here"
 	// CustomServiceConfig - customize the service config using this parameter to change service defaults,
 	// or overwrite rendered information using raw OpenStack config format. The content gets added to
 	// to /etc/<service>/<service>.conf.d directory as custom.conf file.

--- a/api/v1beta1/cinderbackup_types.go
+++ b/api/v1beta1/cinderbackup_types.go
@@ -45,7 +45,7 @@ type CinderBackupSpec struct {
 	// +kubebuilder:default=cinder
 	// DatabaseUser - optional username used for cinder DB, defaults to cinder
 	// TODO: -> implement needs work in mariadb-operator, right now only cinder
-	DatabaseUser string `json:"databaseUser,omitempty"`
+	DatabaseUser string `json:"databaseUser"`
 
 	// +kubebuilder:validation:Optional
 	// Secret containing OpenStack password information for CinderDatabasePassword
@@ -58,7 +58,7 @@ type CinderBackupSpec struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default={database: CinderDatabasePassword, service: CinderPassword}
 	// PasswordSelectors - Selectors to identify the DB and ServiceUser password from the Secret
-	PasswordSelectors PasswordSelector `json:"passwordSelectors,omitempty"`
+	PasswordSelectors PasswordSelector `json:"passwordSelectors"`
 
 	// +kubebuilder:validation:Optional
 	// NodeSelector to target subset of worker nodes for running the Backup service
@@ -70,7 +70,6 @@ type CinderBackupSpec struct {
 	Debug CinderServiceDebug `json:"debug,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="# add your customization here"
 	// CustomServiceConfig - customize the service config using this parameter to change service defaults,
 	// or overwrite rendered information using raw OpenStack config format. The content gets added to
 	// to /etc/<service>/<service>.conf.d directory as custom.conf file.

--- a/api/v1beta1/cinderscheduler_types.go
+++ b/api/v1beta1/cinderscheduler_types.go
@@ -46,7 +46,7 @@ type CinderSchedulerSpec struct {
 	// +kubebuilder:default=cinder
 	// DatabaseUser - optional username used for cinder DB, defaults to cinder
 	// TODO: -> implement needs work in mariadb-operator, right now only cinder
-	DatabaseUser string `json:"databaseUser,omitempty"`
+	DatabaseUser string `json:"databaseUser"`
 
 	// +kubebuilder:validation:Optional
 	// Secret containing OpenStack password information for CinderDatabasePassword
@@ -59,7 +59,7 @@ type CinderSchedulerSpec struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default={database: CinderDatabasePassword, service: CinderPassword}
 	// PasswordSelectors - Selectors to identify the DB and ServiceUser password from the Secret
-	PasswordSelectors PasswordSelector `json:"passwordSelectors,omitempty"`
+	PasswordSelectors PasswordSelector `json:"passwordSelectors"`
 
 	// +kubebuilder:validation:Optional
 	// NodeSelector to target subset of worker nodes running this service. Setting here overrides
@@ -72,7 +72,6 @@ type CinderSchedulerSpec struct {
 	Debug CinderServiceDebug `json:"debug,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="# add your customization here"
 	// CustomServiceConfig - customize the service config using this parameter to change service defaults,
 	// or overwrite rendered information using raw OpenStack config format. The content gets added to
 	// to /etc/<service>/<service>.conf.d directory as custom.conf file.

--- a/api/v1beta1/cindervolume_types.go
+++ b/api/v1beta1/cindervolume_types.go
@@ -47,7 +47,7 @@ type CinderVolumeSpec struct {
 	// +kubebuilder:default=cinder
 	// DatabaseUser - optional username used for cinder DB, defaults to cinder
 	// TODO: -> implement needs work in mariadb-operator, right now only cinder
-	DatabaseUser string `json:"databaseUser,omitempty"`
+	DatabaseUser string `json:"databaseUser"`
 
 	// +kubebuilder:validation:Optional
 	// Secret containing OpenStack password information for CinderDatabasePassword
@@ -60,7 +60,7 @@ type CinderVolumeSpec struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default={database: CinderDatabasePassword, service: CinderPassword}
 	// PasswordSelectors - Selectors to identify the DB and ServiceUser password from the Secret
-	PasswordSelectors PasswordSelector `json:"passwordSelectors,omitempty"`
+	PasswordSelectors PasswordSelector `json:"passwordSelectors"`
 
 	// +kubebuilder:validation:Optional
 	// NodeSelector to target subset of worker nodes running this service. Setting here overrides
@@ -73,7 +73,6 @@ type CinderVolumeSpec struct {
 	Debug CinderServiceDebug `json:"debug,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="# add your customization here"
 	// CustomServiceConfig - customize the service config using this parameter to change service defaults,
 	// or overwrite rendered information using raw OpenStack config format. The content gets added to
 	// to /etc/<service>/<service>.conf.d directory as custom.conf file.

--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -24,11 +24,11 @@ type PasswordSelector struct {
 	// +kubebuilder:default="CinderDatabasePassword"
 	// Database - Selector to get the cinder database user password from the Secret
 	// TODO: not used, need change in mariadb-operator
-	Database string `json:"database,omitempty"`
+	Database string `json:"database"`
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default="CinderPassword"
 	// Service - Selector to get the cinder service password from the Secret
-	Service string `json:"service,omitempty"`
+	Service string `json:"service"`
 }
 
 // CinderDebug indicates whether certain stages of Cinder deployment should
@@ -37,11 +37,11 @@ type CinderDebug struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=false
 	// dbInitContainer enable debug (waits until /tmp/stop-init-container disappears)
-	DBInitContainer bool `json:"dbInitContainer,omitempty"`
+	DBInitContainer bool `json:"dbInitContainer"`
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=false
 	// dbSync enable debug
-	DBSync bool `json:"dbSync,omitempty"`
+	DBSync bool `json:"dbSync"`
 }
 
 // CinderServiceDebug indicates whether certain stages of Cinder service
@@ -50,11 +50,11 @@ type CinderServiceDebug struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=false
 	// initContainer enable debug (waits until /tmp/stop-init-container disappears)
-	InitContainer bool `json:"initContainer,omitempty"`
+	InitContainer bool `json:"initContainer"`
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=false
 	// service enable debug
-	Service bool `json:"service,omitempty"`
+	Service bool `json:"service"`
 }
 
 // MetalLBConfig to configure the MetalLB loadbalancer service

--- a/config/certmanager/kustomizeconfig.yaml
+++ b/config/certmanager/kustomizeconfig.yaml
@@ -1,4 +1,4 @@
-# This configuration is for teaching kustomize how to update name ref and var substitution 
+# This configuration is for teaching kustomize how to update name ref and var substitution
 nameReference:
 - kind: Issuer
   group: cert-manager.io

--- a/config/crd/bases/cinder.openstack.org_cinderapis.yaml
+++ b/config/crd/bases/cinder.openstack.org_cinderapis.yaml
@@ -43,7 +43,6 @@ spec:
               containerImage:
                 type: string
               customServiceConfig:
-                default: '# add your customization here'
                 type: string
               databaseHostname:
                 type: string

--- a/config/crd/bases/cinder.openstack.org_cinderbackups.yaml
+++ b/config/crd/bases/cinder.openstack.org_cinderbackups.yaml
@@ -43,7 +43,6 @@ spec:
               containerImage:
                 type: string
               customServiceConfig:
-                default: '# add your customization here'
                 type: string
               databaseHostname:
                 type: string

--- a/config/crd/bases/cinder.openstack.org_cinders.yaml
+++ b/config/crd/bases/cinder.openstack.org_cinders.yaml
@@ -41,7 +41,6 @@ spec:
                   containerImage:
                     type: string
                   customServiceConfig:
-                    default: '# add your customization here'
                     type: string
                   databaseHostname:
                     type: string
@@ -913,7 +912,6 @@ spec:
                   containerImage:
                     type: string
                   customServiceConfig:
-                    default: '# add your customization here'
                     type: string
                   databaseHostname:
                     type: string
@@ -1758,7 +1756,6 @@ spec:
                   containerImage:
                     type: string
                   customServiceConfig:
-                    default: '# add your customization here'
                     type: string
                   databaseHostname:
                     type: string
@@ -2605,7 +2602,6 @@ spec:
                     containerImage:
                       type: string
                     customServiceConfig:
-                      default: '# add your customization here'
                       type: string
                     databaseHostname:
                       type: string
@@ -3449,7 +3445,6 @@ spec:
                   type: object
                 type: object
               customServiceConfig:
-                default: '# add your customization here'
                 type: string
               databaseInstance:
                 type: string
@@ -4255,7 +4250,9 @@ spec:
             required:
             - cinderAPI
             - cinderScheduler
+            - databaseInstance
             - rabbitMqClusterName
+            - secret
             type: object
           status:
             properties:

--- a/config/crd/bases/cinder.openstack.org_cinderschedulers.yaml
+++ b/config/crd/bases/cinder.openstack.org_cinderschedulers.yaml
@@ -43,7 +43,6 @@ spec:
               containerImage:
                 type: string
               customServiceConfig:
-                default: '# add your customization here'
                 type: string
               databaseHostname:
                 type: string

--- a/config/crd/bases/cinder.openstack.org_cindervolumes.yaml
+++ b/config/crd/bases/cinder.openstack.org_cindervolumes.yaml
@@ -43,7 +43,6 @@ spec:
               containerImage:
                 type: string
               customServiceConfig:
-                default: '# add your customization here'
                 type: string
               databaseHostname:
                 type: string


### PR DESCRIPTION
* 0.2.1: The fixed finding is about mixing Required and omitempty in the same field def. See https://github.com/gibizer/operator-lint/tree/main/linters/crd/C002 . Note that this makes the Secret and the DatabaseInstance fields properly required.
* 0.3.0: Having a CRD field with omitempty tag with a kubebuilder default value defined can cause unexpected behavior.
See https://github.com/gibizer/operator-lint/blob/main/linters/crd/C003 for details.

