### PR TITLE
Allow cinderbackup to report ready with 0 replicas

### DIFF
--- a/api/v1beta1/cinderapi_types.go
+++ b/api/v1beta1/cinderapi_types.go
@@ -158,5 +158,5 @@ func init() {
 
 // IsReady - returns true if service is ready to serve requests
 func (instance CinderAPI) IsReady() bool {
-	return instance.Status.ReadyCount >= 1
+	return instance.Status.ReadyCount == instance.Spec.Replicas
 }

--- a/api/v1beta1/cinderbackup_types.go
+++ b/api/v1beta1/cinderbackup_types.go
@@ -146,5 +146,5 @@ func init() {
 
 // IsReady - returns true if service is ready to serve requests
 func (instance CinderBackup) IsReady() bool {
-	return instance.Status.ReadyCount >= 1
+	return instance.Status.ReadyCount == instance.Spec.Replicas
 }

--- a/api/v1beta1/cinderscheduler_types.go
+++ b/api/v1beta1/cinderscheduler_types.go
@@ -148,5 +148,5 @@ func init() {
 
 // IsReady - returns true if service is ready to serve requests
 func (instance CinderScheduler) IsReady() bool {
-	return instance.Status.ReadyCount >= 1
+	return instance.Status.ReadyCount == instance.Spec.Replicas
 }

--- a/api/v1beta1/cindervolume_types.go
+++ b/api/v1beta1/cindervolume_types.go
@@ -149,5 +149,5 @@ func init() {
 
 // IsReady - returns true if service is ready to serve requests
 func (instance CinderVolume) IsReady() bool {
-	return instance.Status.ReadyCount >= 1
+	return instance.Status.ReadyCount == instance.Spec.Replicas
 }


### PR DESCRIPTION
Right now the cinder-backup resource gets created with default 0 replicas. With this cinder never reaches ready state without cinder-backup being configured. This change reports Ready state if `Spec.Replicas == ReadyCount`.