### PR TITLE
Fix iscsi lvm

### DIFF
--- a/config/samples/backends/lvm-iscsi/backend.yaml
+++ b/config/samples/backends/lvm-iscsi/backend.yaml
@@ -1,0 +1,25 @@
+# This sample requires an LVM VG with the name of `cinder-volumes` to exist on the OpenShift node where cinder-volume runs
+# It also requires that iscsid and multpathd are running on the host.
+# The correct way to configure and run the daemons is using `MachineConfig` as shown in `iscsid.yaml` and `multipathd.yaml`.
+# To create the LVM on CRC the sample also uses a `MachineConfig` using a systemd unit with file `lvm.yaml`
+#
+# ATTENTION: After applying this OpenShift nodes will reboot, because of the `MachineConfig` changes and will take a while to recover.
+
+apiVersion: core.openstack.org/v1beta1
+kind: OpenStackControlPlane
+metadata:
+  name: openstack
+spec:
+  cinder:
+    template:
+      cinderVolumes:
+        lvm-iscsi:
+          customServiceConfig: |
+            [lvm]
+            image_volume_cache_enabled=false
+            use_multipath_for_image_xfer=true
+            volume_driver=cinder.volume.drivers.lvm.LVMVolumeDriver
+            volume_group=cinder-volumes
+            target_protocol=iscsi
+            target_helper=lioadm
+            volume_backend_name=lvm_iscsi

--- a/config/samples/backends/lvm-iscsi/iscsid.yaml
+++ b/config/samples/backends/lvm-iscsi/iscsid.yaml
@@ -1,0 +1,15 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: master
+    service: cinder
+  name: 99-master-cinder-enable-iscsid
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    systemd:
+      units:
+      - enabled: true
+        name: iscsid.service

--- a/config/samples/backends/lvm-iscsi/kustomization.yaml
+++ b/config/samples/backends/lvm-iscsi/kustomization.yaml
@@ -1,0 +1,7 @@
+resources:
+  - iscsid.yaml
+  - multipathd.yaml
+  - lvm.yaml
+  - ./../bases
+patches:
+  - backend.yaml

--- a/config/samples/backends/lvm-iscsi/lvm.yaml
+++ b/config/samples/backends/lvm-iscsi/lvm.yaml
@@ -1,0 +1,35 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: master
+    service: cinder
+    component: cinder-volume
+  name: 99-master-cinder-lvm-losetup
+spec:
+  config:
+    ignition:
+      version:  3.2.0
+    Systemd:
+      Units:
+      - name: cinder-lvm-losetup.service
+        enabled: true
+        Contents:  |
+          [Unit]
+          Description=Cinder LVM losetup
+          DefaultDependencies=no
+          Conflicts=umount.target
+          Requires=lvm2-monitor.service systemd-udev-settle.service
+          Before=local-fs.target umount.target
+          After=var.mount lvm2-monitor.service systemd-udev-settle.service
+
+          [Service]
+          Environment=VG_GB_SIZE=10G
+          Environment=LOOPBACK_FILE=/var/home/core/cinder-volumes
+          Type=oneshot
+          ExecStart=bash -c "if [[ ! -e ${LOOPBACK_FILE} ]]; then /bin/truncate -s ${VG_GB_SIZE} ${LOOPBACK_FILE} && /sbin/vgcreate cinder-volumes `/sbin/losetup --show -f ${LOOPBACK_FILE}`; else /sbin/losetup -f ${LOOPBACK_FILE}; fi"
+          ExecStop=bash -c "/sbin/losetup -d `/sbin/losetup -j ${LOOPBACK_FILE} -l -n -O NAME`"
+          RemainAfterExit=yes
+
+          [Install]
+          WantedBy=local-fs-pre.target

--- a/config/samples/backends/lvm-iscsi/multipathd.yaml
+++ b/config/samples/backends/lvm-iscsi/multipathd.yaml
@@ -1,0 +1,30 @@
+# Includes the /etc/multipathd.conf contents and the systemd unit changes
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: master
+    service: cinder
+  name: 99-master-cinder-enable-multipathd
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    storage:
+      files:
+        - path: /etc/multipath.conf
+          overwrite: false
+          # Mode must be decimal, this is 0600
+          mode: 384
+          user:
+            name: root
+          group:
+            name: root
+          contents:
+            # Source can be a http, https, tftp, s3, gs, or data as defined in rfc2397.
+            # This is the rfc2397 text/plain string format
+            source: data:,defaults%20%7B%0A%20%20user_friendly_names%20no%0A%20%20skip_kpartx%20yes%0A%20%20find_multipaths%20yes%0A%7D%0A%0Ablacklist%20%7B%0A%7D
+    systemd:
+      units:
+      - enabled: true
+        name: multipathd.service

--- a/pkg/cinder/volumes.go
+++ b/pkg/cinder/volumes.go
@@ -108,15 +108,6 @@ func GetVolumes(name string, storageSvc bool, extraVol []cinderv1beta1.CinderExt
 					},
 				},
 			},
-			{
-				Name: "var-lib-iscsi",
-				VolumeSource: corev1.VolumeSource{
-					HostPath: &corev1.HostPathVolumeSource{
-						Path: "/var/lib/iscsi",
-						Type: &dirOrCreate,
-					},
-				},
-			},
 			// os-brick locks need to be shared between the different volume
 			// consumers (available in OSP18)
 			{
@@ -229,10 +220,6 @@ func GetVolumeMounts(storageSvc bool, extraVol []cinderv1beta1.CinderExtraVolMou
 			{
 				Name:      "sys",
 				MountPath: "/sys",
-			},
-			{
-				Name:      "var-lib-iscsi",
-				MountPath: "/var/lib/iscsi",
 			},
 			{
 				Name:      "var-locks-brick",

--- a/pkg/cinderbackup/statefulset.go
+++ b/pkg/cinderbackup/statefulset.go
@@ -126,6 +126,10 @@ func StatefulSet(
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: cinder.ServiceAccount,
+					// Some commands need to be run on the host using nsenter
+					// (eg: iscsi commands) so we need to share the PID
+					// namespace with the host.
+					HostPID: true,
 					Containers: []corev1.Container{
 						{
 							Name: cinder.ServiceName + "-backup",

--- a/pkg/cindervolume/statefulset.go
+++ b/pkg/cindervolume/statefulset.go
@@ -126,6 +126,10 @@ func StatefulSet(
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: cinder.ServiceAccount,
+					// Some commands need to be run on the host using nsenter
+					// (eg: iscsi commands) so we need to share the PID
+					// namespace with the host.
+					HostPID: true,
 					Containers: []corev1.Container{
 						{
 							Name: cinder.ServiceName + "-volume",

--- a/templates/cinder/bin/run-on-host
+++ b/templates/cinder/bin/run-on-host
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec nsenter -a -t 1 -- `realpath -s $0` "$@"

--- a/templates/cinder/config/cinder-backup-config.json
+++ b/templates/cinder/config/cinder-backup-config.json
@@ -6,6 +6,30 @@
       "dest": "/etc/cinder/cinder.conf.d",
       "owner": "root:cinder",
       "perm": "0750"
+    },
+    {
+      "source": "/usr/local/bin/container-scripts/run-on-host",
+      "dest": "/usr/sbin/multipath",
+      "owner": "root:root",
+      "perm": "0755"
+    },
+    {
+      "source": "/usr/local/bin/container-scripts/run-on-host",
+      "dest": "/usr/sbin/multipathd",
+      "owner": "root:root",
+      "perm": "0755"
+    },
+    {
+      "source": "/usr/local/bin/container-scripts/run-on-host",
+      "dest": "/usr/sbin/iscsiadm",
+      "owner": "root:root",
+      "perm": "0755"
+    },
+    {
+      "source": "/usr/local/bin/container-scripts/run-on-host",
+      "dest": "/lib/udev/scsi_id",
+      "owner": "root:root",
+      "perm": "0755"
     }
   ]
 }

--- a/templates/cinder/config/cinder-volume-config.json
+++ b/templates/cinder/config/cinder-volume-config.json
@@ -30,6 +30,12 @@
       "dest": "/lib/udev/scsi_id",
       "owner": "root:root",
       "perm": "0755"
+    },
+    {
+      "source": "/usr/local/bin/container-scripts/run-on-host",
+      "dest": "/usr/sbin/lvm",
+      "owner": "root:root",
+      "perm": "0755"
     }
   ]
 }

--- a/templates/cinder/config/cinder-volume-config.json
+++ b/templates/cinder/config/cinder-volume-config.json
@@ -6,6 +6,30 @@
       "dest": "/etc/cinder/cinder.conf.d",
       "owner": "root:cinder",
       "perm": "0750"
+    },
+    {
+      "source": "/usr/local/bin/container-scripts/run-on-host",
+      "dest": "/usr/sbin/multipath",
+      "owner": "root:root",
+      "perm": "0755"
+    },
+    {
+      "source": "/usr/local/bin/container-scripts/run-on-host",
+      "dest": "/usr/sbin/multipathd",
+      "owner": "root:root",
+      "perm": "0755"
+    },
+    {
+      "source": "/usr/local/bin/container-scripts/run-on-host",
+      "dest": "/usr/sbin/iscsiadm",
+      "owner": "root:root",
+      "perm": "0755"
+    },
+    {
+      "source": "/usr/local/bin/container-scripts/run-on-host",
+      "dest": "/lib/udev/scsi_id",
+      "owner": "root:root",
+      "perm": "0755"
     }
   ]
 }


### PR DESCRIPTION
Fix iSCSI and multipathd on cinder volume and backup pods.
To allow testing it we also fix the LVM driver and provide a simple mechanism to run this backend on CRC.

In OpenShift the approach is to have iscsid and multipathd running on the host and using `nsenter` inside the container to communicate with them.

Commit messages have additional information.