### PR TITLE
Add NFS backend config sample

### DIFF
--- a/config/samples/backends/nfs/backend.yaml
+++ b/config/samples/backends/nfs/backend.yaml
@@ -1,0 +1,20 @@
+# Deploy a cinder NFS backend, with sensitive server settings (the nas_host
+# and nas_share_path) stored in the "cinder-volume-nfs-secrets" Secret.
+apiVersion: core.openstack.org/v1beta1
+kind: OpenStackControlPlane
+metadata:
+  name: openstack
+spec:
+  cinder:
+    template:
+      cinderVolumes:
+        nfs:
+          customServiceConfig: |
+            [nfs]
+            volume_backend_name=nfs
+            volume_driver=cinder.volume.drivers.nfs.NfsDriver
+            nfs_snapshot_support=true
+            nas_secure_file_operations=false
+            nas_secure_file_permissions=false
+          customServiceConfigSecrets:
+          - cinder-volume-nfs-secrets

--- a/config/samples/backends/nfs/cinder-volume-nfs-secrets.yaml
+++ b/config/samples/backends/nfs/cinder-volume-nfs-secrets.yaml
@@ -1,0 +1,15 @@
+# Define the "cinder-volume-nfs-secrets" Secret that contains sensitive
+# information pertaining to the [nfs] backend.
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    service: cinder
+    component: cinder-volume
+  name: cinder-volume-nfs-secrets
+type: Opaque
+stringData:
+  nfs-secrets.conf: |
+    [nfs]
+    nas_host=192.168.130.1
+    nas_share_path=/var/nfs/cinder

--- a/config/samples/backends/nfs/kustomization.yaml
+++ b/config/samples/backends/nfs/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+  - ./../bases
+  - cinder-volume-nfs-secrets.yaml
+patches:
+  - backend.yaml


### PR DESCRIPTION
This config sample shows how to deploy an NFS backend, with sensitive settings (the nas_host and nas_share_path) stored in a Secret referenced in the backend's customServiceConfigSecrets.