### PR TITLE
Make deploying cinder-backup optional

### DIFF
--- a/config/samples/backends/bases/openstack/openstack.yaml
+++ b/config/samples/backends/bases/openstack/openstack.yaml
@@ -38,7 +38,6 @@ spec:
         replicas: 1
       cinderScheduler:
         replicas: 1
-      # Can omit the cinderBackup section. Making it explicit for reference.
       cinderBackup:
         replicas: 0
   manila:


### PR DESCRIPTION
Many OpenStack deployments do not use the cinder-backup service. With this in mind, the service should not be deployed unless the number of replicas is greater than zero. Conversely, the deployment should be cleaned up (deleted) if the service is scaled down to zero replicas.