### PR TITLE
Add service and component labels to more objects

### DIFF
--- a/controllers/cinderbackup_controller.go
+++ b/controllers/cinderbackup_controller.go
@@ -268,7 +268,6 @@ func (r *CinderBackupReconciler) reconcileInit(
 	ctx context.Context,
 	instance *cinderv1beta1.CinderBackup,
 	helper *helper.Helper,
-	serviceLabels map[string]string,
 ) (ctrl.Result, error) {
 	r.Log.Info(fmt.Sprintf("Reconciling Service '%s' init", instance.Name))
 
@@ -347,10 +346,15 @@ func (r *CinderBackupReconciler) reconcileNormal(ctx context.Context, instance *
 	// Create ConfigMaps required as input for the Service and calculate an overall hash of hashes
 	//
 
+	serviceLabels := map[string]string{
+		common.AppSelector:       cinder.ServiceName,
+		common.ComponentSelector: cinderbackup.Component,
+	}
+
 	//
 	// create custom Configmap for this cinder backup service
 	//
-	err = r.generateServiceConfigMaps(ctx, helper, instance, &configMapVars)
+	err = r.generateServiceConfigMaps(ctx, helper, instance, &configMapVars, serviceLabels)
 	if err != nil {
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.ServiceConfigReadyCondition,
@@ -387,11 +391,6 @@ func (r *CinderBackupReconciler) reconcileNormal(ctx context.Context, instance *
 	// TODO check when/if Init, Update, or Upgrade should/could be skipped
 	//
 
-	serviceLabels := map[string]string{
-		common.AppSelector:       cinder.ServiceName,
-		common.ComponentSelector: cinderbackup.Component,
-	}
-
 	// networks to attach to
 	for _, netAtt := range instance.Spec.NetworkAttachments {
 		_, err := nad.GetNADWithName(ctx, helper, netAtt, instance.Namespace)
@@ -422,7 +421,7 @@ func (r *CinderBackupReconciler) reconcileNormal(ctx context.Context, instance *
 	}
 
 	// Handle service init
-	ctrlResult, err = r.reconcileInit(ctx, instance, helper, serviceLabels)
+	ctrlResult, err = r.reconcileInit(ctx, instance, helper)
 	if err != nil {
 		return ctrlResult, err
 	} else if (ctrlResult != ctrl.Result{}) {
@@ -578,13 +577,14 @@ func (r *CinderBackupReconciler) generateServiceConfigMaps(
 	h *helper.Helper,
 	instance *cinderv1beta1.CinderBackup,
 	envVars *map[string]env.Setter,
+	serviceLabels map[string]string,
 ) error {
 	//
 	// create custom Configmap for cinder-backup-specific config input
 	// - %-config-data configmap holding custom config for the service's cinder.conf
 	//
 
-	cmLabels := labels.GetLabels(instance, labels.GetGroupLabel(cinder.ServiceName), map[string]string{})
+	cmLabels := labels.GetLabels(instance, labels.GetGroupLabel(cinder.ServiceName), serviceLabels)
 
 	// customData hold any customization for the service.
 	// custom.conf is going to be merged into /etc/cinder/conder.conf

--- a/controllers/cinderscheduler_controller.go
+++ b/controllers/cinderscheduler_controller.go
@@ -268,7 +268,6 @@ func (r *CinderSchedulerReconciler) reconcileInit(
 	ctx context.Context,
 	instance *cinderv1beta1.CinderScheduler,
 	helper *helper.Helper,
-	serviceLabels map[string]string,
 ) (ctrl.Result, error) {
 	r.Log.Info(fmt.Sprintf("Reconciling Service '%s' init", instance.Name))
 
@@ -347,10 +346,15 @@ func (r *CinderSchedulerReconciler) reconcileNormal(ctx context.Context, instanc
 	// Create ConfigMaps required as input for the Service and calculate an overall hash of hashes
 	//
 
+	serviceLabels := map[string]string{
+		common.AppSelector:       cinder.ServiceName,
+		common.ComponentSelector: cinderscheduler.Component,
+	}
+
 	//
 	// create custom Configmap for this cinder scheduler service
 	//
-	err = r.generateServiceConfigMaps(ctx, helper, instance, &configMapVars)
+	err = r.generateServiceConfigMaps(ctx, helper, instance, &configMapVars, serviceLabels)
 	if err != nil {
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.ServiceConfigReadyCondition,
@@ -387,11 +391,6 @@ func (r *CinderSchedulerReconciler) reconcileNormal(ctx context.Context, instanc
 	// TODO check when/if Init, Update, or Upgrade should/could be skipped
 	//
 
-	serviceLabels := map[string]string{
-		common.AppSelector:       cinder.ServiceName,
-		common.ComponentSelector: cinderscheduler.Component,
-	}
-
 	// networks to attach to
 	for _, netAtt := range instance.Spec.NetworkAttachments {
 		_, err := nad.GetNADWithName(ctx, helper, netAtt, instance.Namespace)
@@ -422,7 +421,7 @@ func (r *CinderSchedulerReconciler) reconcileNormal(ctx context.Context, instanc
 	}
 
 	// Handle service init
-	ctrlResult, err = r.reconcileInit(ctx, instance, helper, serviceLabels)
+	ctrlResult, err = r.reconcileInit(ctx, instance, helper)
 	if err != nil {
 		return ctrlResult, err
 	} else if (ctrlResult != ctrl.Result{}) {
@@ -578,13 +577,14 @@ func (r *CinderSchedulerReconciler) generateServiceConfigMaps(
 	h *helper.Helper,
 	instance *cinderv1beta1.CinderScheduler,
 	envVars *map[string]env.Setter,
+	serviceLabels map[string]string,
 ) error {
 	//
 	// create custom Configmap for cinder-scheduler-specific config input
 	// - %-config-data configmap holding custom config for the service's cinder.conf
 	//
 
-	cmLabels := labels.GetLabels(instance, labels.GetGroupLabel(cinder.ServiceName), map[string]string{})
+	cmLabels := labels.GetLabels(instance, labels.GetGroupLabel(cinder.ServiceName), serviceLabels)
 
 	// customData hold any customization for the service.
 	// custom.conf is going to be merged into /etc/cinder/conder.conf

--- a/pkg/cinderapi/deployment.go
+++ b/pkg/cinderapi/deployment.go
@@ -85,6 +85,7 @@ func Deployment(
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cinder.ServiceName,
 			Namespace: instance.Namespace,
+			Labels:    labels,
 		},
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{

--- a/pkg/cinderbackup/statefulset.go
+++ b/pkg/cinderbackup/statefulset.go
@@ -113,6 +113,7 @@ func StatefulSet(
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      instance.Name,
 			Namespace: instance.Namespace,
+			Labels:    labels,
 		},
 		Spec: appsv1.StatefulSetSpec{
 			Selector: &metav1.LabelSelector{

--- a/pkg/cinderscheduler/statefulset.go
+++ b/pkg/cinderscheduler/statefulset.go
@@ -103,6 +103,7 @@ func StatefulSet(
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      instance.Name,
 			Namespace: instance.Namespace,
+			Labels:    labels,
 		},
 		Spec: appsv1.StatefulSetSpec{
 			Selector: &metav1.LabelSelector{

--- a/pkg/cindervolume/statefulset.go
+++ b/pkg/cindervolume/statefulset.go
@@ -113,6 +113,7 @@ func StatefulSet(
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      instance.Name,
 			Namespace: instance.Namespace,
+			Labels:    labels,
 		},
 		Spec: appsv1.StatefulSetSpec{
 			Selector: &metav1.LabelSelector{


### PR DESCRIPTION
Add the service and component labels to the c-api Deployment, and c-bak, c-sch and c-vol StatefulSets, and to all ConfigMaps.

This significantly improves the ability to search for all resources owned by cinder, or one of its components:

  oc get all -l service=cinder
  oc get all -l component=cinder-volume

"oc get all" doesn't list Secrets or ConfigMaps, but these can also be queried.

  oc get secret -l service=cinder
  oc get cm -l component=cinder-volume