### PR TITLE
Enhancements to default cinder.conf

### DIFF
--- a/config/samples/backends/lvm-iscsi/backend.yaml
+++ b/config/samples/backends/lvm-iscsi/backend.yaml
@@ -17,7 +17,6 @@ spec:
           customServiceConfig: |
             [lvm]
             image_volume_cache_enabled=false
-            use_multipath_for_image_xfer=true
             volume_driver=cinder.volume.drivers.lvm.LVMVolumeDriver
             volume_group=cinder-volumes
             target_protocol=iscsi

--- a/templates/cinder/bin/init.sh
+++ b/templates/cinder/bin/init.sh
@@ -67,6 +67,9 @@ password = ${PASSWORD}
 
 [nova]
 password = ${PASSWORD}
+
+[service_user]
+password = ${PASSWORD}
 EOF
 
 if [ -f ${DEFAULT_DIR}/custom.conf ]; then

--- a/templates/cinder/config/cinder.conf
+++ b/templates/cinder/config/cinder.conf
@@ -1,5 +1,4 @@
 [DEFAULT]
-# transport_url = rabbit://openstack:RABBIT_PASS@controller
 auth_strategy = keystone
 # TODO: Decide if we want the operator to generate the api servers, which is
 #       more efficient when creating volumes from image (no keystone requests).
@@ -8,7 +7,7 @@ auth_strategy = keystone
 glance_catalog_info = image:glance:internalURL
 storage_availability_zone = nova
 default_availability_zone = nova
-# TODO: should we create our own default type
+# TODO: should we create our own default type?
 #default_volume_type = openstack-k8s
 scheduler_driver = cinder.scheduler.filter_scheduler.FilterScheduler
 
@@ -27,10 +26,18 @@ api_paste_config = /etc/cinder/api-paste.ini
 # that would make cinder-api logs be treated as errors by httpd
 log_file = /dev/stdout
 
+[backend_defaults]
+use_multipath_for_image_xfer = true
+
 [database]
-# connection = mysql+pymysql://cinder:CINDER_DBPASS@controller/cinder
 max_retries = -1
 db_max_retries = -1
+
+[os_brick]
+lock_path = /var/locks/openstack/os-brick
+
+[oslo_concurrency]
+lock_path = /var/locks/openstack/cinder
 
 # TODO:
 #[oslo_messaging_notifications]
@@ -65,19 +72,11 @@ user_domain_name = Default
 project_name = service
 project_domain_name = Default
 
-#TODO
-#[service_user]
-#send_service_user_token = True
-#TODO
-#auth_url = http://keystone.openstack.svc:5000/
-#project_name = service
-#project_domain_name = Default
-#username = cinder
-#user_domain_name = Default
-#auth_type = password
-
-[oslo_concurrency]
-lock_path = /var/locks/openstack/cinder
-
-[os_brick]
-lock_path = /var/locks/openstack/os-brick
+[service_user]
+send_service_user_token = True
+auth_url = {{ .KeystoneInternalURL }}
+auth_type = password
+project_domain_name = Default
+user_domain_name = Default
+project_name = service
+username = {{ .ServiceUser }}


### PR DESCRIPTION
- Add [backend_defaults] and set use_multipath_for_image_xfer True
- Configure the [service_user] section
- Minor cleanup: removed obsolete comments, and sort the sections alphabetically. The sorting isn't critcal, but I didn't like seeing the oslo sections scattered all over the place.