### PR TITLE
Use consistent words for keywords

### DIFF
--- a/config/manifests/bases/cinder-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/cinder-operator.clusterserviceversion.yaml
@@ -54,8 +54,9 @@ spec:
   - supported: true
     type: AllNamespaces
   keywords:
-  - openstack
-  - cn-openstack
+  - OpenStack
+  - Block Storage
+  - Cinder
   links:
   - name: Cinder Operator
     url: https://github.com/openstack-k8s-operators/cinder-operator


### PR DESCRIPTION
This updates the keywords of cinder CRD so that the items are more consistent with the other operators.