### PR TITLE
Remove leftover api sub module

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -77,5 +77,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
-
-replace github.com/openstack-k8s-operators/lib-common/modules/common => github.com/stuggi/lib-common/modules/common v0.0.0-20230324094302-1d404fbea435

--- a/api/go.sum
+++ b/api/go.sum
@@ -284,8 +284,6 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/stuggi/lib-common/modules/common v0.0.0-20230324094302-1d404fbea435 h1:EnDRx2X5xk3fkLp19inzXUXuYmhs/FwPvAyWzTeAAYg=
-github.com/stuggi/lib-common/modules/common v0.0.0-20230324094302-1d404fbea435/go.mod h1:D9riTIFxv/vxN9jR42YTBtJQz3pBFh5yCxtBtgJAc0U=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=


### PR DESCRIPTION
This patch removes the leftover replacement of the lib-common library in the api sub module.