### PR TITLE
Fix cinder-api pod name

### DIFF
--- a/pkg/cinderapi/deployment.go
+++ b/pkg/cinderapi/deployment.go
@@ -83,7 +83,7 @@ func Deployment(
 
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      cinder.ServiceName,
+			Name:      instance.Name,
 			Namespace: instance.Namespace,
 			Labels:    labels,
 		},

--- a/tests/kuttl/common/assert_sample_deployment.yaml
+++ b/tests/kuttl/common/assert_sample_deployment.yaml
@@ -28,7 +28,7 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: cinder
+  name: cinder-api
   namespace: openstack
   ownerReferences:
   - apiVersion: cinder.openstack.org/v1beta1


### PR DESCRIPTION
Use instance.Name so that "-api" will appear in the pod name. Now c-api pods will be named like this:

  cinder-api-58ccfdc568-6lg6m

whereas they previously looked like this:

  cinder-58ccfdc568-6lg6m