### PR TITLE
Remove install_yamls dependency for kuttl tests

### DIFF
--- a/tests/kuttl/tests/cinder_scale/01-deploy-cinder.yaml
+++ b/tests/kuttl/tests/cinder_scale/01-deploy-cinder.yaml
@@ -2,5 +2,5 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - script: |
-      PWD=$INSTALL_YAMLS
-      make -C $INSTALL_YAMLS cinder_deploy
+      cp ../../../../config/samples/cinder_v1beta1_cinder.yaml deploy
+      oc kustomize deploy | oc apply -n openstack -f -

--- a/tests/kuttl/tests/cinder_scale/05-cleanup-cinder.yaml
+++ b/tests/kuttl/tests/cinder_scale/05-cleanup-cinder.yaml
@@ -2,5 +2,5 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - script: |
-      PWD=$INSTALL_YAMLS
-      make -C $INSTALL_YAMLS cinder_deploy_cleanup
+      oc kustomize deploy | oc delete -n openstack -f -
+      rm deploy/cinder_v1beta1_cinder.yaml

--- a/tests/kuttl/tests/cinder_scale/deploy/kustomization.yaml
+++ b/tests/kuttl/tests/cinder_scale/deploy/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ./cinder_v1beta1_cinder.yaml
+patches:
+- patch: |-
+    - op: replace
+      path: /spec/secret
+      value: osp-secret
+  target:
+    kind: Cinder


### PR DESCRIPTION
Instead of using install_yamls targets for deploying and cleaning up
cinder, use the CR sample from config/samples. This removes a possible
circular dependency issue when using install_yamls to run the jobs and
to run some test steps.
