### PR TITLE
Replace TripleO images by TCIB images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -354,10 +354,10 @@ operator-lint: $(LOCALBIN) gowork
 # $oc delete -n openstack mutatingwebhookconfiguration/mcinder.kb.io
 SKIP_CERT ?=false
 .PHONY: run-with-webhook
-run-with-webhook: export CINDER_API_IMAGE_URL_DEFAULT=quay.io/tripleozedcentos9/openstack-cinder-api:current-tripleo
-run-with-webhook: export CINDER_BACKUP_IMAGE_URL_DEFAULT=quay.io/tripleozedcentos9/openstack-cinder-backup:current-tripleo
-run-with-webhook: export CINDER_SCHEDULER_IMAGE_URL_DEFAULT=quay.io/tripleozedcentos9/openstack-cinder-scheduler:current-tripleo
-run-with-webhook: export CINDER_VOLUME_IMAGE_URL_DEFAULT=quay.io/tripleozedcentos9/openstack-cinder-volume:current-tripleo
+run-with-webhook: export CINDER_API_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-cinder-api:current-podified
+run-with-webhook: export CINDER_BACKUP_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-cinder-backup:current-podified
+run-with-webhook: export CINDER_SCHEDULER_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-cinder-scheduler:current-podified
+run-with-webhook: export CINDER_VOLUME_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-cinder-volume:current-podified
 run-with-webhook: manifests generate fmt vet ## Run a controller from your host.
 	/bin/bash hack/configure_local_webhook.sh
 	go run ./main.go

--- a/README.md
+++ b/README.md
@@ -113,13 +113,13 @@ spec:
   databaseUser: cinder
   cinderAPI:
     replicas: 1
-    containerImage: quay.io/tripleowallabycentos9/openstack-cinder-api:current-tripleo
+    containerImage: quay.io/podified-antelopecentos9/openstack-cinder-api:current-podified
   cinderScheduler:
     replicas: 1
-    containerImage: quay.io/tripleowallabycentos9/openstack-cinder-scheduler:current-tripleo
+    containerImage: quay.io/podified-antelopecentos9/openstack-cinder-scheduler:current-podified
   cinderBackup:
     replicas: 1
-    containerImage: quay.io/tripleowallabycentos9/openstack-cinder-backup:current-tripleo
+    containerImage: quay.io/podified-antelopecentos9/openstack-cinder-backup:current-podified
     customServiceConfig: |
       [DEFAULT]
       backup_driver = cinder.backup.drivers.ceph.CephBackupDriver
@@ -128,7 +128,7 @@ spec:
   secret: cinder-secret
   cinderVolumes:
     volume1:
-      containerImage: quay.io/tripleowallabycentos9/openstack-cinder-volume:current-tripleo
+      containerImage: quay.io/podified-antelopecentos9/openstack-cinder-volume:current-podified
       replicas: 1
       customServiceConfig: |
         [DEFAULT]

--- a/config/default/manager_default_images.yaml
+++ b/config/default/manager_default_images.yaml
@@ -12,10 +12,10 @@ spec:
       - name: manager
         env:
         - name: CINDER_API_IMAGE_URL_DEFAULT
-          value: quay.io/tripleozedcentos9/openstack-cinder-api:current-tripleo
+          value: quay.io/podified-antelope-centos9/openstack-cinder-api:current-podified
         - name: CINDER_BACKUP_IMAGE_URL_DEFAULT
-          value: quay.io/tripleozedcentos9/openstack-cinder-backup:current-tripleo
+          value: quay.io/podified-antelope-centos9/openstack-cinder-backup:current-podified
         - name: CINDER_SCHEDULER_IMAGE_URL_DEFAULT
-          value: quay.io/tripleozedcentos9/openstack-cinder-scheduler:current-tripleo
+          value: quay.io/podified-antelope-centos9/openstack-cinder-scheduler:current-podified
         - name: CINDER_VOLUME_IMAGE_URL_DEFAULT
-          value: quay.io/tripleozedcentos9/openstack-cinder-volume:current-tripleo
+          value: quay.io/podified-antelope-centos9/openstack-cinder-volume:current-podified

--- a/config/samples/cinder_v1beta1_cinder.yaml
+++ b/config/samples/cinder_v1beta1_cinder.yaml
@@ -13,15 +13,15 @@ spec:
   rabbitMqClusterName: rabbitmq
   cinderAPI:
     replicas: 1
-    containerImage: quay.io/tripleozedcentos9/openstack-cinder-api:current-tripleo
+    containerImage: quay.io/podified-antelope-centos9/openstack-cinder-api:current-podified
   cinderScheduler:
     replicas: 1
-    containerImage: quay.io/tripleozedcentos9/openstack-cinder-scheduler:current-tripleo
+    containerImage: quay.io/podified-antelope-centos9/openstack-cinder-scheduler:current-podified
   cinderBackup:
     replicas: 1
-    containerImage: quay.io/tripleozedcentos9/openstack-cinder-backup:current-tripleo
+    containerImage: quay.io/podified-antelope-centos9/openstack-cinder-backup:current-podified
   secret: cinder-secret
   cinderVolumes:
     volume1:
-      containerImage: quay.io/tripleozedcentos9/openstack-cinder-volume:current-tripleo
+      containerImage: quay.io/podified-antelope-centos9/openstack-cinder-volume:current-podified
       replicas: 1

--- a/tests/kuttl/common/assert_sample_deployment.yaml
+++ b/tests/kuttl/common/assert_sample_deployment.yaml
@@ -13,16 +13,16 @@ spec:
   rabbitMqClusterName: rabbitmq
   cinderAPI:
     replicas: 1
-    containerImage: quay.io/tripleozedcentos9/openstack-cinder-api:current-tripleo
+    containerImage: quay.io/podified-antelope-centos9/openstack-cinder-api:current-podified
   cinderScheduler:
     replicas: 1
-    containerImage: quay.io/tripleozedcentos9/openstack-cinder-scheduler:current-tripleo
+    containerImage: quay.io/podified-antelope-centos9/openstack-cinder-scheduler:current-podified
   cinderBackup:
     replicas: 1
-    containerImage: quay.io/tripleozedcentos9/openstack-cinder-backup:current-tripleo
+    containerImage: quay.io/podified-antelope-centos9/openstack-cinder-backup:current-podified
   cinderVolumes:
     volume1:
-      containerImage: quay.io/tripleozedcentos9/openstack-cinder-volume:current-tripleo
+      containerImage: quay.io/podified-antelope-centos9/openstack-cinder-volume:current-podified
       replicas: 1
 ---
 apiVersion: apps/v1
@@ -72,7 +72,7 @@ spec:
         - /usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start
         command:
         - /bin/bash
-        image: quay.io/tripleozedcentos9/openstack-cinder-api:current-tripleo
+        image: quay.io/podified-antelope-centos9/openstack-cinder-api:current-podified
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -143,7 +143,7 @@ spec:
           value: cinder
         - name: CustomConf
           value: custom.conf
-        image: quay.io/tripleozedcentos9/openstack-cinder-api:current-tripleo
+        image: quay.io/podified-antelope-centos9/openstack-cinder-api:current-podified
         imagePullPolicy: IfNotPresent
         name: init
         resources: {}


### PR DESCRIPTION
We imported container build tools from TripleO as TCIB[1]. Now we are retiring TripleO and should complete the migration.

[1] https://github.com/openstack-k8s-operators/tcib