### PR TITLE
Add cinder-backup mount for /var/lib/cinder

### DIFF
--- a/pkg/cinderbackup/volumes.go
+++ b/pkg/cinderbackup/volumes.go
@@ -67,6 +67,10 @@ func GetInitVolumeMounts(secretNames []string, extraVol []cinderv1beta1.CinderEx
 func GetVolumeMounts(extraVol []cinderv1beta1.CinderExtraVolMounts) []corev1.VolumeMount {
 	volumeMounts := []corev1.VolumeMount{
 		{
+			Name:      "var-lib-cinder",
+			MountPath: "/var/lib/cinder",
+		},
+		{
 			Name:      "etc-nvme",
 			MountPath: "/etc/nvme",
 		},


### PR DESCRIPTION
A previous patch created the appropriate volume so that cinder-backup has access to /var/lib/cinder, but it neglected to mount the volume.