### PR TITLE
Remove unused constant for admin endpoint

### DIFF
--- a/pkg/cinder/const.go
+++ b/pkg/cinder/const.go
@@ -33,8 +33,6 @@ const (
 	// DatabaseName -
 	DatabaseName = "cinder"
 
-	// CinderAdminPort -
-	CinderAdminPort int32 = 8776
 	// CinderPublicPort -
 	CinderPublicPort int32 = 8776
 	// CinderInternalPort -


### PR DESCRIPTION
The constant has not been used since we stopped creating admin endpoint.