### PR TITLE
normalize checking bundle as well for leftovers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,11 +13,11 @@ repos:
       entry: make
       args: ["tidy"]
       pass_filenames: false
-    - id: make-manifests
-      name: make-manifests
+    - id: make-bundle
+      name: make-bundle
       language: system
       entry: make
-      args: ['manifests']
+      args: ['bundle']
       pass_filenames: false
     - id: make-generate
       name: make-generate


### PR DESCRIPTION
witch to checking make bundle instead of just manifests since make bundle calls manifests as well