### PR TITLE
Validate input for Replicas spec

### DIFF
--- a/api/bases/cinder.openstack.org_cinderapis.yaml
+++ b/api/bases/cinder.openstack.org_cinderapis.yaml
@@ -871,6 +871,8 @@ spec:
               replicas:
                 default: 1
                 format: int32
+                maximum: 32
+                minimum: 0
                 type: integer
               resources:
                 properties:

--- a/api/bases/cinder.openstack.org_cinderbackups.yaml
+++ b/api/bases/cinder.openstack.org_cinderbackups.yaml
@@ -845,6 +845,8 @@ spec:
               replicas:
                 default: 1
                 format: int32
+                maximum: 1
+                minimum: 0
                 type: integer
               resources:
                 properties:

--- a/api/bases/cinder.openstack.org_cinders.yaml
+++ b/api/bases/cinder.openstack.org_cinders.yaml
@@ -96,6 +96,8 @@ spec:
                   replicas:
                     default: 1
                     format: int32
+                    maximum: 32
+                    minimum: 0
                     type: integer
                   resources:
                     properties:
@@ -165,6 +167,8 @@ spec:
                   replicas:
                     default: 1
                     format: int32
+                    maximum: 1
+                    minimum: 0
                     type: integer
                   resources:
                     properties:
@@ -234,6 +238,8 @@ spec:
                   replicas:
                     default: 1
                     format: int32
+                    maximum: 1
+                    minimum: 0
                     type: integer
                   resources:
                     properties:
@@ -305,6 +311,7 @@ spec:
                       default: 1
                       format: int32
                       maximum: 1
+                      minimum: 0
                       type: integer
                     resources:
                       properties:

--- a/api/bases/cinder.openstack.org_cinderschedulers.yaml
+++ b/api/bases/cinder.openstack.org_cinderschedulers.yaml
@@ -845,6 +845,8 @@ spec:
               replicas:
                 default: 1
                 format: int32
+                maximum: 1
+                minimum: 0
                 type: integer
               resources:
                 properties:

--- a/api/bases/cinder.openstack.org_cindervolumes.yaml
+++ b/api/bases/cinder.openstack.org_cindervolumes.yaml
@@ -846,6 +846,7 @@ spec:
                 default: 1
                 format: int32
                 maximum: 1
+                minimum: 0
                 type: integer
               resources:
                 properties:

--- a/api/v1beta1/cinderapi_types.go
+++ b/api/v1beta1/cinderapi_types.go
@@ -28,6 +28,8 @@ type CinderAPITemplate struct {
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=1
+	// +kubebuilder:validation:Maximum=32
+	// +kubebuilder:validation:Minimum=0
 	// Replicas - Cinder API Replicas
 	Replicas int32 `json:"replicas"`
 

--- a/api/v1beta1/cinderbackup_types.go
+++ b/api/v1beta1/cinderbackup_types.go
@@ -28,6 +28,8 @@ type CinderBackupTemplate struct {
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=1
+	// +kubebuilder:validation:Maximum=1
+	// +kubebuilder:validation:Minimum=0
 	// Replicas - Cinder Backup Replicas
 	Replicas int32 `json:"replicas"`
 }

--- a/api/v1beta1/cinderscheduler_types.go
+++ b/api/v1beta1/cinderscheduler_types.go
@@ -28,6 +28,8 @@ type CinderSchedulerTemplate struct {
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=1
+	// +kubebuilder:validation:Maximum=1
+	// +kubebuilder:validation:Minimum=0
 	// Replicas - Cinder Scheduler Replicas
 	Replicas int32 `json:"replicas"`
 }

--- a/api/v1beta1/cindervolume_types.go
+++ b/api/v1beta1/cindervolume_types.go
@@ -29,6 +29,7 @@ type CinderVolumeTemplate struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=1
 	// +kubebuilder:validation:Maximum=1
+	// +kubebuilder:validation:Minimum=0
 	// Replicas - Cinder Volume Replicas
 	Replicas int32 `json:"replicas"`
 }

--- a/config/crd/bases/cinder.openstack.org_cinderapis.yaml
+++ b/config/crd/bases/cinder.openstack.org_cinderapis.yaml
@@ -871,6 +871,8 @@ spec:
               replicas:
                 default: 1
                 format: int32
+                maximum: 32
+                minimum: 0
                 type: integer
               resources:
                 properties:

--- a/config/crd/bases/cinder.openstack.org_cinderbackups.yaml
+++ b/config/crd/bases/cinder.openstack.org_cinderbackups.yaml
@@ -845,6 +845,8 @@ spec:
               replicas:
                 default: 1
                 format: int32
+                maximum: 1
+                minimum: 0
                 type: integer
               resources:
                 properties:

--- a/config/crd/bases/cinder.openstack.org_cinders.yaml
+++ b/config/crd/bases/cinder.openstack.org_cinders.yaml
@@ -96,6 +96,8 @@ spec:
                   replicas:
                     default: 1
                     format: int32
+                    maximum: 32
+                    minimum: 0
                     type: integer
                   resources:
                     properties:
@@ -165,6 +167,8 @@ spec:
                   replicas:
                     default: 1
                     format: int32
+                    maximum: 1
+                    minimum: 0
                     type: integer
                   resources:
                     properties:
@@ -234,6 +238,8 @@ spec:
                   replicas:
                     default: 1
                     format: int32
+                    maximum: 1
+                    minimum: 0
                     type: integer
                   resources:
                     properties:
@@ -305,6 +311,7 @@ spec:
                       default: 1
                       format: int32
                       maximum: 1
+                      minimum: 0
                       type: integer
                     resources:
                       properties:

--- a/config/crd/bases/cinder.openstack.org_cinderschedulers.yaml
+++ b/config/crd/bases/cinder.openstack.org_cinderschedulers.yaml
@@ -845,6 +845,8 @@ spec:
               replicas:
                 default: 1
                 format: int32
+                maximum: 1
+                minimum: 0
                 type: integer
               resources:
                 properties:

--- a/config/crd/bases/cinder.openstack.org_cindervolumes.yaml
+++ b/config/crd/bases/cinder.openstack.org_cindervolumes.yaml
@@ -846,6 +846,7 @@ spec:
                 default: 1
                 format: int32
                 maximum: 1
+                minimum: 0
                 type: integer
               resources:
                 properties:


### PR DESCRIPTION
This adds minimum/maximum value for Replicas spec to avoid accepting a negative number or a too large number. The maximum number follows what is used in keystone-operator.