### PR TITLE
Stop mouting localtime from host

### DIFF
--- a/pkg/cinder/volumes.go
+++ b/pkg/cinder/volumes.go
@@ -24,14 +24,6 @@ func GetVolumes(name string, storageSvc bool, extraVol []cinderv1beta1.CinderExt
 			},
 		},
 		{
-			Name: "etc-localtime",
-			VolumeSource: corev1.VolumeSource{
-				HostPath: &corev1.HostPathVolumeSource{
-					Path: "/etc/localtime",
-				},
-			},
-		},
-		{
 			Name: "scripts",
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
@@ -177,11 +169,6 @@ func GetVolumeMounts(storageSvc bool, extraVol []cinderv1beta1.CinderExtraVolMou
 		{
 			Name:      "etc-machine-id",
 			MountPath: "/etc/machine-id",
-			ReadOnly:  true,
-		},
-		{
-			Name:      "etc-localtime",
-			MountPath: "/etc/localtime",
 			ReadOnly:  true,
 		},
 		{

--- a/tests/kuttl/common/assert_sample_deployment.yaml
+++ b/tests/kuttl/common/assert_sample_deployment.yaml
@@ -104,9 +104,6 @@ spec:
         - mountPath: /etc/machine-id
           name: etc-machine-id
           readOnly: true
-        - mountPath: /etc/localtime
-          name: etc-localtime
-          readOnly: true
         - mountPath: /usr/local/bin/container-scripts
           name: scripts
           readOnly: true
@@ -171,10 +168,6 @@ spec:
           path: /etc/machine-id
           type: ""
         name: etc-machine-id
-      - hostPath:
-          path: /etc/localtime
-          type: ""
-        name: etc-localtime
       - configMap:
           defaultMode: 493
           name: cinder-scripts


### PR DESCRIPTION
In general we should avoid mounting hostpath in k8s pods. Timezone can be configured using TZ environment and this is more flexible. (For example we can configure timezone different from the one used in the platform.)