### PR TITLE
Backup: Enable multipathing by default

### DIFF
--- a/templates/cinder/config/00-config.conf
+++ b/templates/cinder/config/00-config.conf
@@ -27,6 +27,8 @@ api_paste_config = /etc/cinder/api-paste.ini
 # that would make cinder-api logs be treated as errors by httpd
 log_file = /dev/stdout
 
+use_multipath_for_image_xfer = true
+
 [backend_defaults]
 use_multipath_for_image_xfer = true
 


### PR DESCRIPTION
The default for cinder volume service is to enable multipathing, but we are missing this on the backup service.

This patch enables multipathing by default for backup services as well.