### PR TITLE
DBSync: Bump service versions

### DIFF
--- a/pkg/cinder/dbsync.go
+++ b/pkg/cinder/dbsync.go
@@ -11,6 +11,13 @@ import (
 
 const (
 	// DBSyncCommand -
+	// TODO: Once we work on update/upgrades revisit the command in the
+	//       the db-sync-config.json file.
+	//       If we stop all services during the update/upgrade then we can keep
+	//       the --bump-versions flag.
+	//       If we are doing rolling upgrades we'll need to use the flag
+	//       conditionally (only for adoption) and do the restart cycle of
+	//       services as described in the upstream rolling upgrades process.
 	DBSyncCommand = "/usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start"
 )
 

--- a/templates/cinder/config/db-sync-config.json
+++ b/templates/cinder/config/db-sync-config.json
@@ -1,3 +1,3 @@
 {
-  "command": "/usr/bin/cinder-manage --config-dir /etc/cinder/cinder.conf.d db sync"
+  "command": "/usr/bin/cinder-manage --config-dir /etc/cinder/cinder.conf.d db sync --bump-versions"
 }


### PR DESCRIPTION
When adopting the cinder services we end up with the services getting pinned to the old RPC and OVO versions, and to fix that we would need to restart the services.  This is the standard rolling upgrades mechanism.

Since the adoption is more like an offline update/upgrade we need to bump these versions in the DB before we start them so they all start with the right versions.

The `cinder-manage db sync` command has a flag specifically designed for this purpose: `--bump-versions`

This patch adds this flag to the job that syncs the DB.

Once we start working on updates and upgrades we'll have to revisit this to see if we need to tweak it or not.