### PR TITLE
Fix cinder-api logging to stdout

### DIFF
--- a/templates/cinder/config/cinder-api-config.json
+++ b/templates/cinder/config/cinder-api-config.json
@@ -1,5 +1,5 @@
 {
-  "command": "/usr/sbin/httpd -DFOREGROUND",
+  "command": "usermod -a -G tty cinder; /usr/sbin/httpd -DFOREGROUND",
   "config_files": [
     {
       "source": "/var/lib/config-data/merged/cinder.conf.d",


### PR DESCRIPTION
On commit 64a5e288ef977be47fead7941d5489d72142f8f2 we made the logs go to /dev/stdout to make the API service logs not appear as [wsgi:error], but on some deployments we now find that the Cinder-API service returns status code 500 and doesn't work at all.

Inside the API logs we see error:
  PermissionError: [Errno 13] Permission denied: '/dev/stdout'

Recurrently looking at permissions of /dev/stdout we find:

  [cinder@cinder-api-54859ccfbd-pqxwf ~]$ ls -la /dev/stdout
  lrwxrwxrwx. 1 root root 15 Jun 28 19:41 /dev/stdout -> /proc/self/fd/1

  [cinder@cinder-api-54859ccfbd-pqxwf ~]$ ls -la /proc/self/fd/1
  lrwx------. 1 cinder cinder 64 Jun 28 20:01 /proc/self/fd/1 -> /dev/pts/0

  [cinder@cinder-api-54859ccfbd-pqxwf ~]$ ls -la /dev/pts/0
  crw--w----. 1 root tty 136, 0 Jun 28 20:01 /dev/pts/0

Other cinder-services (scheduler, volume, and backup) don't have this issue because they run as root, but httpd doesn't allow to run mod_wsgi as root, so we are running it as cinder, as seen in templates/cinder/config/10-cinder_wsgi.conf:

  WSGIDaemonProcess cinder-api display-name=cinder_wsgi group=cinder processes=4 threads=1 user=cinder

This patch does a temporary fix by adding the Cinder user to the tty group before starting the httpd service.

Ideally the cinder base image would be modified to include the cinder user from the start, so a review has been submitted to do precisely that: https://review.opendev.org/c/openstack/kolla/+/887370