### PR TITLE
Fix Backup getting restarted

### DIFF
--- a/templates/cinder/config/00-config.conf
+++ b/templates/cinder/config/00-config.conf
@@ -18,6 +18,12 @@ scheduler_driver = cinder.scheduler.filter_scheduler.FilterScheduler
 # scheduler.
 scheduler_driver_init_wait_time = 30
 
+# Workaround for https://bugs.launchpad.net/cinder/+bug/2026877
+# Cinder backup will appear as down with concurrent backup/restore operations.
+# Until bug is fixed we just increase the amount of time needed to report the
+# service as being down.
+service_down_time=180
+
 # osapi_volume_listen=controller-0.internalapi.redhat.local
 osapi_volume_workers = 4
 control_exchange = openstack


### PR DESCRIPTION
Due to a bug in the cinder backup service [1] the service may appear to be down when doing multiple concurrent operations.

When the service appears as down the probe will detect it and will end up restarting the service, which aborts all the ongoing operations.

While the bug is getting fixed we increase the service_down_time to 3 minutes. This is not ideal because it also affects the cinder volume service, but it also prevents human operators from seeing the false down state.

The alternative would be to change the probing configuration just for the backup service.

[1]: https://bugs.launchpad.net/cinder/+bug/2026877