### PR TITLE
Change kuttl tests to run in any namespace

### DIFF
--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -1,7 +1,7 @@
 #
 # EXECUTION (from install_yamls repo root):
 #
-#   make kuttl_keystone
+#   make cinder_kuttl
 #
 # ASSUMPTIONS:
 #
@@ -18,7 +18,7 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestSuite
 reportFormat: JSON
 reportName: kuttl-test-cinder
-namespace: openstack
+namespace: cinder-kuttl-tests
 timeout: 180
 parallel: 1
 suppress:

--- a/tests/kuttl/common/assert_sample_deployment.yaml
+++ b/tests/kuttl/common/assert_sample_deployment.yaml
@@ -2,7 +2,6 @@ apiVersion: cinder.openstack.org/v1beta1
 kind: Cinder
 metadata:
   name: cinder
-  namespace: openstack
 spec:
   serviceUser: cinder
   customServiceConfig: |
@@ -29,7 +28,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cinder-api
-  namespace: openstack
   ownerReferences:
   - apiVersion: cinder.openstack.org/v1beta1
     blockOwnerDeletion: true

--- a/tests/kuttl/tests/cinder_scale/01-deploy-cinder.yaml
+++ b/tests/kuttl/tests/cinder_scale/01-deploy-cinder.yaml
@@ -3,4 +3,4 @@ kind: TestStep
 commands:
   - script: |
       cp ../../../../config/samples/cinder_v1beta1_cinder.yaml deploy
-      oc kustomize deploy | oc apply -n openstack -f -
+      oc kustomize deploy | oc apply -n $NAMESPACE -f -

--- a/tests/kuttl/tests/cinder_scale/05-cleanup-cinder.yaml
+++ b/tests/kuttl/tests/cinder_scale/05-cleanup-cinder.yaml
@@ -2,5 +2,5 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - script: |
-      oc kustomize deploy | oc delete -n openstack -f -
+      oc kustomize deploy | oc delete -n $NAMESPACE -f -
       rm deploy/cinder_v1beta1_cinder.yaml

--- a/tests/kuttl/tests/cinder_scale/05-errors.yaml
+++ b/tests/kuttl/tests/cinder_scale/05-errors.yaml
@@ -11,10 +11,8 @@ apiVersion: cinder.openstack.org/v1beta1
 kind: Cinder
 metadata:
   name: cinder
-  namespace: openstack
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cinder
-  namespace: openstack

--- a/tests/kuttl/tests/cinder_scale/deploy/kustomization.yaml
+++ b/tests/kuttl/tests/cinder_scale/deploy/kustomization.yaml
@@ -7,5 +7,7 @@ patches:
     - op: replace
       path: /spec/secret
       value: osp-secret
+    - op: replace
+      path: /metadata/namespace
   target:
     kind: Cinder


### PR DESCRIPTION
Modify the kuttl tests so that they can run in any namespace, not just
in the openstack one. This requires removing any mention of the
namespace in the asserts and using the $NAMESPACE variable in scripts
instead of the namespace name.

Needs https://github.com/openstack-k8s-operators/install_yamls/pull/410 to be
merged for CI to pass.
