### PR TITLE
sidecar logging for cinder-api

### DIFF
--- a/controllers/cinderapi_controller.go
+++ b/controllers/cinderapi_controller.go
@@ -779,6 +779,10 @@ func (r *CinderAPIReconciler) generateServiceConfigs(
 	}
 	customData[cinder.CustomServiceConfigSecretsFileName] = customSecrets
 
+	// Inject Default logging
+	customData[cinder.CustomServiceConfigFileName] = fmt.Sprintf("%s%s%s\n",
+		string(cinderSecret.Data[cinder.CustomServiceConfigFileName]), cinder.LogSnippet, cinderapi.LogPath)
+
 	configTemplates := []util.Template{
 		{
 			Name:         fmt.Sprintf("%s-config-data", instance.Name),

--- a/controllers/cinderbackup_controller.go
+++ b/controllers/cinderbackup_controller.go
@@ -576,6 +576,10 @@ func (r *CinderBackupReconciler) generateServiceConfigs(
 	}
 	customData[cinder.CustomServiceConfigSecretsFileName] = customSecrets
 
+	// Inject Default logging
+	customData[cinder.CustomServiceConfigFileName] = fmt.Sprintf("%s%s%s\n",
+		string(cinderSecret.Data[cinder.CustomServiceConfigFileName]), cinder.LogSnippet, cinder.DefaultLogPath)
+
 	configTemplates := []util.Template{
 		{
 			Name:         fmt.Sprintf("%s-config-data", instance.Name),

--- a/controllers/cinderscheduler_controller.go
+++ b/controllers/cinderscheduler_controller.go
@@ -575,6 +575,10 @@ func (r *CinderSchedulerReconciler) generateServiceConfigs(
 	}
 	customData[cinder.CustomServiceConfigSecretsFileName] = customSecrets
 
+	// Inject Default logging
+	customData[cinder.CustomServiceConfigFileName] = fmt.Sprintf("%s%s%s\n",
+		string(cinderSecret.Data[cinder.CustomServiceConfigFileName]), cinder.LogSnippet, cinder.DefaultLogPath)
+
 	configTemplates := []util.Template{
 		{
 			Name:         fmt.Sprintf("%s-config-data", instance.Name),

--- a/pkg/cinder/const.go
+++ b/pkg/cinder/const.go
@@ -65,6 +65,11 @@ const (
 	// Cinder is the global ServiceType that refers to all the components deployed
 	// by the cinder operator
 	Cinder storage.PropagationType = "Cinder"
+	//LogSnippet -
+	LogSnippet = "[DEFAULT]\n" +
+		"log_file="
+	//DefaultLogPath -
+	DefaultLogPath = "/dev/stdout"
 )
 
 // DbsyncPropagation keeps track of the DBSync Service Propagation Type

--- a/pkg/cinderapi/const.go
+++ b/pkg/cinderapi/const.go
@@ -21,4 +21,10 @@ const (
 
 	// Component -
 	Component = "cinder-api"
+
+	//LogPath -
+	LogPath = "/var/log/cinder/cinder-api.log"
+
+	// logVolume -
+	logVolume = "logs"
 )

--- a/pkg/cinderapi/volumes.go
+++ b/pkg/cinderapi/volumes.go
@@ -37,3 +37,22 @@ func GetVolumeMounts(extraVol []cinderv1beta1.CinderExtraVolMounts) []corev1.Vol
 
 	return append(cinder.GetVolumeMounts(false, extraVol, cinder.CinderAPIPropagation), volumeMounts...)
 }
+
+// GetLogVolumeMount - Cinder API LogVolumeMount
+func GetLogVolumeMount() corev1.VolumeMount {
+	return corev1.VolumeMount{
+		Name:      logVolume,
+		MountPath: "/var/log/cinder",
+		ReadOnly:  false,
+	}
+}
+
+// GetLogVolume - Cinder API LogVolume
+func GetLogVolume() corev1.Volume {
+	return corev1.Volume{
+		Name: logVolume,
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{Medium: ""},
+		},
+	}
+}

--- a/templates/cinder/config/00-config.conf
+++ b/templates/cinder/config/00-config.conf
@@ -23,10 +23,6 @@ osapi_volume_workers = 4
 control_exchange = openstack
 api_paste_config = /etc/cinder/api-paste.ini
 
-# For containers we want to log to stdout instead of the default stderr, as
-# that would make cinder-api logs be treated as errors by httpd
-log_file = /dev/stdout
-
 use_multipath_for_image_xfer = true
 
 [backend_defaults]

--- a/templates/cinder/config/cinder-api-config.json
+++ b/templates/cinder/config/cinder-api-config.json
@@ -13,5 +13,12 @@
       "owner": "root",
       "perm": "0644"
     }
+  ],
+  "permissions": [
+      {
+          "path": "/var/log/cinder",
+          "owner": "cinder:cinder",
+          "recurse": true
+      }
   ]
 }


### PR DESCRIPTION
cinder-api is failing in ocp 4.12+ due to the recent permission denied error on `/dev/stdout`.
For this reason it might be a good idea  introduce a sidecar container to stream logs.
This is consistent with the k8s official pattern [1].

[1] https://kubernetes.io/docs/concepts/cluster-administration/logging