### PR TITLE
 Require databaseHostname and transportURLSecret

### DIFF
--- a/api/bases/cinder.openstack.org_cinderapis.yaml
+++ b/api/bases/cinder.openstack.org_cinderapis.yaml
@@ -912,8 +912,10 @@ spec:
                 type: string
             required:
             - containerImage
+            - databaseHostname
             - secret
             - serviceAccount
+            - transportURLSecret
             type: object
           status:
             properties:

--- a/api/bases/cinder.openstack.org_cinderbackups.yaml
+++ b/api/bases/cinder.openstack.org_cinderbackups.yaml
@@ -886,8 +886,10 @@ spec:
                 type: string
             required:
             - containerImage
+            - databaseHostname
             - secret
             - serviceAccount
+            - transportURLSecret
             type: object
           status:
             properties:

--- a/api/bases/cinder.openstack.org_cinderschedulers.yaml
+++ b/api/bases/cinder.openstack.org_cinderschedulers.yaml
@@ -886,8 +886,10 @@ spec:
                 type: string
             required:
             - containerImage
+            - databaseHostname
             - secret
             - serviceAccount
+            - transportURLSecret
             type: object
           status:
             properties:

--- a/api/bases/cinder.openstack.org_cindervolumes.yaml
+++ b/api/bases/cinder.openstack.org_cindervolumes.yaml
@@ -887,8 +887,10 @@ spec:
                 type: string
             required:
             - containerImage
+            - databaseHostname
             - secret
             - serviceAccount
+            - transportURLSecret
             type: object
           status:
             properties:

--- a/api/v1beta1/cinderapi_types.go
+++ b/api/v1beta1/cinderapi_types.go
@@ -45,17 +45,14 @@ type CinderAPISpec struct {
 	// Input parameters for the Cinder API service
 	CinderAPITemplate `json:",inline"`
 
-	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Required
 	// DatabaseHostname - Cinder Database Hostname
-	DatabaseHostname string `json:"databaseHostname,omitempty"`
+	DatabaseHostname string `json:"databaseHostname"`
 
-	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Required
 	// Secret containing RabbitMq transport URL
-	TransportURLSecret string `json:"transportURLSecret,omitempty"`
+	TransportURLSecret string `json:"transportURLSecret"`
 
-	// +kubebuilder:validation:Optional
-	// Debug - enable debug for different deploy stages. If an init container is used, it runs and the
-	// actual action pod gets started with sleep infinity
 	// +kubebuilder:validation:Optional
 	// ExtraMounts containing conf files and credentials
 	ExtraMounts []CinderExtraVolMounts `json:"extraMounts,omitempty"`

--- a/api/v1beta1/cinderbackup_types.go
+++ b/api/v1beta1/cinderbackup_types.go
@@ -41,13 +41,13 @@ type CinderBackupSpec struct {
 	// Input parameters for the Cinder Backup service
 	CinderBackupTemplate `json:",inline"`
 
-	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Required
 	// DatabaseHostname - Cinder Database Hostname
-	DatabaseHostname string `json:"databaseHostname,omitempty"`
+	DatabaseHostname string `json:"databaseHostname"`
 
-	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Required
 	// Secret containing RabbitMq transport URL
-	TransportURLSecret string `json:"transportURLSecret,omitempty"`
+	TransportURLSecret string `json:"transportURLSecret"`
 
 	// +kubebuilder:validation:Optional
 	// ExtraMounts containing conf files and credentials

--- a/api/v1beta1/cinderscheduler_types.go
+++ b/api/v1beta1/cinderscheduler_types.go
@@ -41,13 +41,13 @@ type CinderSchedulerSpec struct {
 	// Input parameters for the Cinder Scheduler service
 	CinderSchedulerTemplate `json:",inline"`
 
-	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Required
 	// DatabaseHostname - Cinder Database Hostname
-	DatabaseHostname string `json:"databaseHostname,omitempty"`
+	DatabaseHostname string `json:"databaseHostname"`
 
-	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Required
 	// Secret containing RabbitMq transport URL
-	TransportURLSecret string `json:"transportURLSecret,omitempty"`
+	TransportURLSecret string `json:"transportURLSecret"`
 
 	// +kubebuilder:validation:Optional
 	// ExtraMounts containing conf files and credentials

--- a/api/v1beta1/cindervolume_types.go
+++ b/api/v1beta1/cindervolume_types.go
@@ -42,13 +42,13 @@ type CinderVolumeSpec struct {
 	// Input parameters for the Cinder Volume service
 	CinderVolumeTemplate `json:",inline"`
 
-	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Required
 	// DatabaseHostname - Cinder Database Hostname
-	DatabaseHostname string `json:"databaseHostname,omitempty"`
+	DatabaseHostname string `json:"databaseHostname"`
 
-	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Required
 	// Secret containing RabbitMq transport URL
-	TransportURLSecret string `json:"transportURLSecret,omitempty"`
+	TransportURLSecret string `json:"transportURLSecret"`
 
 	// +kubebuilder:validation:Optional
 	// ExtraMounts containing conf files and credentials

--- a/config/crd/bases/cinder.openstack.org_cinderapis.yaml
+++ b/config/crd/bases/cinder.openstack.org_cinderapis.yaml
@@ -912,8 +912,10 @@ spec:
                 type: string
             required:
             - containerImage
+            - databaseHostname
             - secret
             - serviceAccount
+            - transportURLSecret
             type: object
           status:
             properties:

--- a/config/crd/bases/cinder.openstack.org_cinderbackups.yaml
+++ b/config/crd/bases/cinder.openstack.org_cinderbackups.yaml
@@ -886,8 +886,10 @@ spec:
                 type: string
             required:
             - containerImage
+            - databaseHostname
             - secret
             - serviceAccount
+            - transportURLSecret
             type: object
           status:
             properties:

--- a/config/crd/bases/cinder.openstack.org_cinderschedulers.yaml
+++ b/config/crd/bases/cinder.openstack.org_cinderschedulers.yaml
@@ -886,8 +886,10 @@ spec:
                 type: string
             required:
             - containerImage
+            - databaseHostname
             - secret
             - serviceAccount
+            - transportURLSecret
             type: object
           status:
             properties:

--- a/config/crd/bases/cinder.openstack.org_cindervolumes.yaml
+++ b/config/crd/bases/cinder.openstack.org_cindervolumes.yaml
@@ -887,8 +887,10 @@ spec:
                 type: string
             required:
             - containerImage
+            - databaseHostname
             - secret
             - serviceAccount
+            - transportURLSecret
             type: object
           status:
             properties:


### PR DESCRIPTION
These spec fields are required to deploy cinder services.

Although we currently do not intend to support direct usage of sub CRs, requiring these fields allows us to catch any bug in cinder controller.