### PR TITLE
Support service specific config snippets

### DIFF
--- a/controllers/cinderapi_controller.go
+++ b/controllers/cinderapi_controller.go
@@ -779,21 +779,19 @@ func (r *CinderAPIReconciler) generateServiceConfigs(
 	}
 	customData[cinder.CustomServiceConfigSecretsFileName] = customSecrets
 
-	// Inject Default logging: /dev/stdout doesn't work for cinder-api and a
-	// sidecar container is used to stream the logs to the defined LogPath.
-	// The following line makes the cinder-operator responsible to append to the
-	// ServiceConfig the logging line by default.
-	customData[cinder.CustomServiceConfigFileName] = fmt.Sprintf("%s\n%s%s\n",
-		string(cinderSecret.Data[cinder.CustomServiceConfigFileName]), cinder.LogSnippet, cinderapi.LogPath)
+	templateParameters := map[string]interface{}{
+		"LogFile": cinderapi.LogFile,
+	}
 
 	configTemplates := []util.Template{
 		{
-			Name:         fmt.Sprintf("%s-config-data", instance.Name),
-			Namespace:    instance.Namespace,
-			Type:         util.TemplateTypeConfig,
-			InstanceType: instance.Kind,
-			CustomData:   customData,
-			Labels:       labels,
+			Name:          fmt.Sprintf("%s-config-data", instance.Name),
+			Namespace:     instance.Namespace,
+			Type:          util.TemplateTypeConfig,
+			InstanceType:  instance.Kind,
+			CustomData:    customData,
+			ConfigOptions: templateParameters,
+			Labels:        labels,
 		},
 	}
 

--- a/pkg/cinder/const.go
+++ b/pkg/cinder/const.go
@@ -33,12 +33,14 @@ const (
 
 	// DefaultsConfigFileName -
 	DefaultsConfigFileName = "00-config.conf"
+	// ServiceConfigFileName -
+	ServiceConfigFileName = "01-config.conf"
 	// CustomConfigFileName -
-	CustomConfigFileName = "01-config.conf"
+	CustomConfigFileName = "02-config.conf"
 	// CustomServiceConfigFileName -
-	CustomServiceConfigFileName = "02-config.conf"
+	CustomServiceConfigFileName = "03-config.conf"
 	// CustomServiceConfigSecretsFileName -
-	CustomServiceConfigSecretsFileName = "03-config.conf"
+	CustomServiceConfigSecretsFileName = "04-config.conf"
 
 	// CinderPublicPort -
 	CinderPublicPort int32 = 8776
@@ -62,8 +64,6 @@ const (
 	// Cinder is the global ServiceType that refers to all the components deployed
 	// by the cinder operator
 	Cinder storage.PropagationType = "Cinder"
-	//LogSnippet -
-	LogSnippet = "[DEFAULT]\nlog_file="
 )
 
 // DbsyncPropagation keeps track of the DBSync Service Propagation Type

--- a/pkg/cinderapi/const.go
+++ b/pkg/cinderapi/const.go
@@ -19,9 +19,6 @@ const (
 	// Component -
 	Component = "cinder-api"
 
-	//LogPath -
-	LogPath = "/var/log/cinder/cinder-api.log"
-
-	// logVolume -
-	logVolume = "logs"
+	//LogFile -
+	LogFile = "/var/log/cinder/cinder-api.log"
 )

--- a/pkg/cinderapi/deployment.go
+++ b/pkg/cinderapi/deployment.go
@@ -106,7 +106,7 @@ func Deployment(
 							Command: []string{
 								"/bin/bash",
 							},
-							Args:  []string{"-c", "tail -n+1 -F " + LogPath},
+							Args:  []string{"-c", "tail -n+1 -F " + LogFile},
 							Image: instance.Spec.ContainerImage,
 							SecurityContext: &corev1.SecurityContext{
 								RunAsUser: &runAsUser,
@@ -125,9 +125,8 @@ func Deployment(
 							SecurityContext: &corev1.SecurityContext{
 								RunAsUser: &runAsUser,
 							},
-							Env: env.MergeEnvs([]corev1.EnvVar{}, envVars),
-							VolumeMounts: append(GetVolumeMounts(instance.Spec.ExtraMounts),
-								[]corev1.VolumeMount{GetLogVolumeMount()}...),
+							Env:            env.MergeEnvs([]corev1.EnvVar{}, envVars),
+							VolumeMounts:   GetVolumeMounts(instance.Spec.ExtraMounts),
 							Resources:      instance.Spec.Resources,
 							ReadinessProbe: readinessProbe,
 							LivenessProbe:  livenessProbe,
@@ -138,10 +137,10 @@ func Deployment(
 			},
 		},
 	}
-	deployment.Spec.Template.Spec.Volumes = append(GetVolumes(
+	deployment.Spec.Template.Spec.Volumes = GetVolumes(
 		cinder.GetOwningCinderName(instance),
 		instance.Name,
-		instance.Spec.ExtraMounts), GetLogVolume())
+		instance.Spec.ExtraMounts)
 
 	// If possible two pods of the same service should not
 	// run on the same worker node. If this is not possible

--- a/pkg/cinderapi/volumes.go
+++ b/pkg/cinderapi/volumes.go
@@ -20,6 +20,12 @@ func GetVolumes(parentName string, name string, extraVol []cinderv1beta1.CinderE
 				},
 			},
 		},
+		{
+			Name: "logs",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{Medium: ""},
+			},
+		},
 	}
 
 	return append(cinder.GetVolumes(parentName, false, extraVol, cinder.CinderAPIPropagation), volumes...)
@@ -39,6 +45,7 @@ func GetVolumeMounts(extraVol []cinderv1beta1.CinderExtraVolMounts) []corev1.Vol
 			SubPath:   "cinder-api-config.json",
 			ReadOnly:  true,
 		},
+		GetLogVolumeMount(),
 	}
 
 	return append(cinder.GetVolumeMounts(false, extraVol, cinder.CinderAPIPropagation), volumeMounts...)
@@ -47,18 +54,8 @@ func GetVolumeMounts(extraVol []cinderv1beta1.CinderExtraVolMounts) []corev1.Vol
 // GetLogVolumeMount - Cinder API LogVolumeMount
 func GetLogVolumeMount() corev1.VolumeMount {
 	return corev1.VolumeMount{
-		Name:      logVolume,
+		Name:      "logs",
 		MountPath: "/var/log/cinder",
 		ReadOnly:  false,
-	}
-}
-
-// GetLogVolume - Cinder API LogVolume
-func GetLogVolume() corev1.Volume {
-	return corev1.Volume{
-		Name: logVolume,
-		VolumeSource: corev1.VolumeSource{
-			EmptyDir: &corev1.EmptyDirVolumeSource{Medium: ""},
-		},
 	}
 }

--- a/templates/cinder/config/00-config.conf
+++ b/templates/cinder/config/00-config.conf
@@ -29,15 +29,6 @@ osapi_volume_workers = 4
 control_exchange = openstack
 api_paste_config = /etc/cinder/api-paste.ini
 
-# For containers we want to log to stdout instead of the default stderr, as
-# that would make cinder-api logs be treated as errors by httpd
-log_file = /dev/stdout
-
-use_multipath_for_image_xfer = true
-
-[backend_defaults]
-use_multipath_for_image_xfer = true
-
 [database]
 connection = {{ .DatabaseConnection }}
 max_retries = -1

--- a/templates/cinderapi/config/01-config.conf
+++ b/templates/cinderapi/config/01-config.conf
@@ -1,0 +1,2 @@
+[DEFAULT]
+log_file = {{ .LogFile }}

--- a/templates/cinderbackup/config/01-config.conf
+++ b/templates/cinderbackup/config/01-config.conf
@@ -1,0 +1,2 @@
+[DEFAULT]
+use_multipath_for_image_xfer = true

--- a/templates/cindervolume/config/01-config.conf
+++ b/templates/cindervolume/config/01-config.conf
@@ -1,0 +1,2 @@
+[backend_defaults]
+use_multipath_for_image_xfer = true


### PR DESCRIPTION
Add support for a new service specific config snippet, which is loaded after the global snippet and before the "custom" global snippet supplied by the user. This adds the ability for the operator to override certain global settings on a per-service basis.

The immediate use case is to provide a cleaner way to override the logging configuration for the cinder-api service.

The [backend_defaults] section in the global snippet has been moved into a new cinder-volume service specific snippet.