### PR TITLE
Clean up GetVolumes() functions

### DIFF
--- a/pkg/cinder/volumes.go
+++ b/pkg/cinder/volumes.go
@@ -52,6 +52,24 @@ func GetVolumes(name string, storageSvc bool, extraVol []cinderv1beta1.CinderExt
 	// Volume and backup services require extra directories
 	if storageSvc {
 		storageVolumes := []corev1.Volume{
+			{
+				Name: "var-lib-cinder",
+				VolumeSource: corev1.VolumeSource{
+					HostPath: &corev1.HostPathVolumeSource{
+						Path: "/var/lib/cinder",
+						Type: &dirOrCreate,
+					},
+				},
+			},
+			{
+				Name: "etc-nvme",
+				VolumeSource: corev1.VolumeSource{
+					HostPath: &corev1.HostPathVolumeSource{
+						Path: "/etc/nvme",
+						Type: &dirOrCreate,
+					},
+				},
+			},
 			// os-brick reads the initiatorname.iscsi from theere
 			{
 				Name: "etc-iscsi",
@@ -159,6 +177,14 @@ func GetVolumeMounts(storageSvc bool, extraVol []cinderv1beta1.CinderExtraVolMou
 	// Volume and backup services require extra directories
 	if storageSvc {
 		storageVolumeMounts := []corev1.VolumeMount{
+			{
+				Name:      "var-lib-cinder",
+				MountPath: "/var/lib/cinder",
+			},
+			{
+				Name:      "etc-nvme",
+				MountPath: "/etc/nvme",
+			},
 			{
 				Name:      "etc-iscsi",
 				MountPath: "/etc/iscsi",

--- a/pkg/cinderapi/deployment.go
+++ b/pkg/cinderapi/deployment.go
@@ -141,7 +141,6 @@ func Deployment(
 	deployment.Spec.Template.Spec.Volumes = append(GetVolumes(
 		cinder.GetOwningCinderName(instance),
 		instance.Name,
-		instance.Spec.CustomServiceConfigSecrets,
 		instance.Spec.ExtraMounts), GetLogVolume())
 
 	// If possible two pods of the same service should not

--- a/pkg/cinderapi/volumes.go
+++ b/pkg/cinderapi/volumes.go
@@ -7,7 +7,7 @@ import (
 )
 
 // GetVolumes -
-func GetVolumes(parentName string, name string, secretNames []string, extraVol []cinderv1beta1.CinderExtraVolMounts) []corev1.Volume {
+func GetVolumes(parentName string, name string, extraVol []cinderv1beta1.CinderExtraVolMounts) []corev1.Volume {
 	var config0644AccessMode int32 = 0644
 
 	volumes := []corev1.Volume{

--- a/pkg/cinderbackup/statefulset.go
+++ b/pkg/cinderbackup/statefulset.go
@@ -164,7 +164,6 @@ func StatefulSet(
 	statefulset.Spec.Template.Spec.Volumes = GetVolumes(
 		cinder.GetOwningCinderName(instance),
 		instance.Name,
-		instance.Spec.CustomServiceConfigSecrets,
 		instance.Spec.ExtraMounts)
 
 	// If possible two pods of the same service should not

--- a/pkg/cinderbackup/volumes.go
+++ b/pkg/cinderbackup/volumes.go
@@ -7,29 +7,10 @@ import (
 )
 
 // GetVolumes -
-func GetVolumes(parentName string, name string, secretNames []string, extraVol []cinderv1beta1.CinderExtraVolMounts) []corev1.Volume {
+func GetVolumes(parentName string, name string, extraVol []cinderv1beta1.CinderExtraVolMounts) []corev1.Volume {
 	var config0644AccessMode int32 = 0644
-	var dirOrCreate = corev1.HostPathDirectoryOrCreate
 
 	volumes := []corev1.Volume{
-		{
-			Name: "var-lib-cinder",
-			VolumeSource: corev1.VolumeSource{
-				HostPath: &corev1.HostPathVolumeSource{
-					Path: "/var/lib/cinder",
-					Type: &dirOrCreate,
-				},
-			},
-		},
-		{
-			Name: "etc-nvme",
-			VolumeSource: corev1.VolumeSource{
-				HostPath: &corev1.HostPathVolumeSource{
-					Path: "/etc/nvme",
-					Type: &dirOrCreate,
-				},
-			},
-		},
 		{
 			Name: "config-data-custom",
 			VolumeSource: corev1.VolumeSource{
@@ -47,14 +28,6 @@ func GetVolumes(parentName string, name string, secretNames []string, extraVol [
 // GetVolumeMounts - Cinder Backup VolumeMounts
 func GetVolumeMounts(extraVol []cinderv1beta1.CinderExtraVolMounts) []corev1.VolumeMount {
 	volumeMounts := []corev1.VolumeMount{
-		{
-			Name:      "var-lib-cinder",
-			MountPath: "/var/lib/cinder",
-		},
-		{
-			Name:      "etc-nvme",
-			MountPath: "/etc/nvme",
-		},
 		{
 			Name:      "config-data-custom",
 			MountPath: "/etc/cinder/cinder.conf.d",

--- a/pkg/cinderscheduler/statefulset.go
+++ b/pkg/cinderscheduler/statefulset.go
@@ -149,7 +149,6 @@ func StatefulSet(
 	statefulset.Spec.Template.Spec.Volumes = GetVolumes(
 		cinder.GetOwningCinderName(instance),
 		instance.Name,
-		instance.Spec.CustomServiceConfigSecrets,
 		instance.Spec.ExtraMounts)
 
 	// If possible two pods of the same service should not

--- a/pkg/cinderscheduler/volumes.go
+++ b/pkg/cinderscheduler/volumes.go
@@ -7,7 +7,7 @@ import (
 )
 
 // GetVolumes -
-func GetVolumes(parentName string, name string, secretNames []string, extraVol []cinderv1beta1.CinderExtraVolMounts) []corev1.Volume {
+func GetVolumes(parentName string, name string, extraVol []cinderv1beta1.CinderExtraVolMounts) []corev1.Volume {
 	var config0644AccessMode int32 = 0644
 
 	volumes := []corev1.Volume{

--- a/pkg/cindervolume/statefulset.go
+++ b/pkg/cindervolume/statefulset.go
@@ -164,7 +164,6 @@ func StatefulSet(
 	statefulset.Spec.Template.Spec.Volumes = GetVolumes(
 		cinder.GetOwningCinderName(instance),
 		instance.Name,
-		instance.Spec.CustomServiceConfigSecrets,
 		instance.Spec.ExtraMounts)
 
 	// If possible two pods of the same service should not

--- a/pkg/cindervolume/volumes.go
+++ b/pkg/cindervolume/volumes.go
@@ -10,29 +10,10 @@ import (
 )
 
 // GetVolumes -
-func GetVolumes(parentName string, name string, secretNames []string, extraVol []cinderv1beta1.CinderExtraVolMounts) []corev1.Volume {
+func GetVolumes(parentName string, name string, extraVol []cinderv1beta1.CinderExtraVolMounts) []corev1.Volume {
 	var config0644AccessMode int32 = 0644
-	var dirOrCreate = corev1.HostPathDirectoryOrCreate
 
 	volumes := []corev1.Volume{
-		{
-			Name: "var-lib-cinder",
-			VolumeSource: corev1.VolumeSource{
-				HostPath: &corev1.HostPathVolumeSource{
-					Path: "/var/lib/cinder",
-					Type: &dirOrCreate,
-				},
-			},
-		},
-		{
-			Name: "etc-nvme",
-			VolumeSource: corev1.VolumeSource{
-				HostPath: &corev1.HostPathVolumeSource{
-					Path: "/etc/nvme",
-					Type: &dirOrCreate,
-				},
-			},
-		},
 		{
 			Name: "config-data-custom",
 			VolumeSource: corev1.VolumeSource{
@@ -62,14 +43,6 @@ func GetVolumeMounts(name string, extraVol []cinderv1beta1.CinderExtraVolMounts)
 			MountPath: "/var/lib/kolla/config_files/config.json",
 			SubPath:   "cinder-volume-config.json",
 			ReadOnly:  true,
-		},
-		{
-			Name:      "var-lib-cinder",
-			MountPath: "/var/lib/cinder",
-		},
-		{
-			Name:      "etc-nvme",
-			MountPath: "/etc/nvme",
 		},
 	}
 


### PR DESCRIPTION
The unused "secretNames" arg is removed from several GetVolumes() functions. Its need was eliminated when the config process was overhauled to not use init containers.

For the cinder-backup and cinder-volume versions of the function, two volumes and their mounts were moved to the top level cinder.GetVolumes() and GetVolumeMounts() functions, which already has specific support for those services.