### PR TITLE
Update cinder.conf defaults

### DIFF
--- a/templates/cinder/config/00-config.conf
+++ b/templates/cinder/config/00-config.conf
@@ -63,7 +63,7 @@ user_domain_name = Default
 project_name = service
 username = {{ .ServiceUser }}
 password = {{ .ServicePassword }}
-#service_token_roles_required = true
+service_token_roles_required = true
 interface = internal
 
 [nova]

--- a/templates/cinder/config/00-config.conf
+++ b/templates/cinder/config/00-config.conf
@@ -6,6 +6,7 @@ auth_strategy = keystone
 #       For now rely on checking the catalog info
 #       glance_api_servers=http://glanceapi.openstack.svc:9292/
 glance_catalog_info = image:glance:internalURL
+allowed_direct_url_schemes = cinder
 storage_availability_zone = nova
 default_availability_zone = nova
 # TODO: should we create our own default type?


### PR DESCRIPTION
This patch updates the global defaults in `00-config.conf` to:

- Check service token roles in the KeyStone middleware.
- Allow cloning of Glance image volumes when Glance is using Cinder as a backend.