### PR TITLE
Improve the backend samples

### DIFF
--- a/config/samples/backends/README.md
+++ b/config/samples/backends/README.md
@@ -26,6 +26,9 @@ Currently available samples are:
 - LVM using NVMe-TCP
 - HPE 3PAR iSCSI
 - HPE 3PAR FC
+- NetApp ONTAP iSCSI
+- NetApp ONTAP FC
+- NetApp ONTAP NFS
 
 **NOTE**: These examples are designed to be applied one at time. If you attempt
 to add a second backend by applying a second example it will result in the

--- a/config/samples/backends/README.md
+++ b/config/samples/backends/README.md
@@ -24,6 +24,8 @@ Currently available samples are:
 - NFS
 - LVM using iSCSI
 - LVM using NVMe-TCP
+- HPE 3PAR iSCSI
+- HPE 3PAR FC
 
 **NOTE**: These examples are designed to be applied one at time. If you attempt
 to add a second backend by applying a second example it will result in the
@@ -62,6 +64,16 @@ we can do everything ourselves.
 If we already have a deployment working we can always use
 `oc kustomize lvm/iscsi | oc apply -f -`. from this directory to make the
 changes.
+
+Some backends, like 3PAR, require a custom container because they have external
+dependencies. So there is a need to build a specific container. In RHOSP
+vendors will provide certified containers through Red Hat's container image
+registry. For illustration and development purposes this repository provides
+samples of what a `Dockerfile` would look like for each of the vendor's. This
+`Dockerfile` will be present in the vendor's directory (e.g. `hpe/Dockerfile`),
+so we would need to build a container, make it available in a registry, and
+then provide it to the cinder operator via the `containerImage` as seen in the
+samples.
 
 ## Ceph example
 

--- a/config/samples/backends/README.md
+++ b/config/samples/backends/README.md
@@ -5,10 +5,14 @@ the `kustomize` configuration management tool available through the `oc
 kustomize` command.
 
 These samples are not meant to serve as deployment recommendations, just as
-working examples to serve as reference.
+working examples to serve as reference, and they use a base OpenStack
+configuration that is unlikely to match any real deployment.
 
 For each backend there will be a `backend.yaml` file containing an overlay for
 the `OpenStackControlPlane` with just the storage related information.
+
+They will usually also have a secrets `yaml` file where we need to replace the
+sample credentials with our real storage ones.
 
 Backend pre-requirements will be listed in that same `backend.yaml` file.
 These can range from having to replace the storage system's address and
@@ -21,28 +25,58 @@ Currently available samples are:
 - LVM using iSCSI
 - LVM using NVMe-TCP
 
+**NOTE**: These examples are designed to be applied one at time. If you attempt
+to add a second backend by applying a second example it will result in the
+first backend being removed. It is certainly possible to define a deployment
+with multiple backends, but that requires a single CR that defines all
+backends.
+
+## Using Examples
+
+Once we have `crc` running making an OpenStack deployment using one of the
+example backends is trivial and it's almost the same as any other deployment
+with the addition of creating and exporting the manifest to use:
+
+```
+$ cd install_yamls
+$ make crc_storage openstack
+$ oc kustomize ../cinder-operator/config/samples/backends/lvm/iscsi > ~/openstack-deployment.yaml
+$ export OPENSTACK_CR=`realpath ~/openstack-deployment.yaml`
+$ make openstack_deploy
+```
+
+Be aware that the some of the Cinder examples (mostly all but NFS and Ceph)
+will reboot your OpenShift cluster because they use `MachineConfig` manifests
+(to deploy things like `iscsid` and `multipathd`) that require a reboot to be
+applied due to the immutability of CoreOS (the underlying OpenShift operating
+system).  This means that the deployment takes longer and the cluster will stop
+responding for a bit.
+
+The reboot will only happen the first time the `MachineConfig` is applied.
+
+For real deployments OpenShift administration may not fall under our
+responsibilities, so we may need to reach to someone else to apply the
+`MachineConfig`, but for our samples we assume we are on a dev environment and
+we can do everything ourselves.
+
+If we already have a deployment working we can always use
+`oc kustomize lvm/iscsi | oc apply -f -`. from this directory to make the
+changes.
+
 ## Ceph example
 
-Once the OpenStack operators are running in your OpenShift cluster and
-the secret `osp-secret` is present, one can deploy OpenStack with a
-specific storage backend with single command.  For example for Ceph we can do:
-`oc kustomize ceph | oc apply -f -`.
-
-The result of the `oc kustomize ceph` command is a complete
-`OpenStackControlPlane` manifest, and we can see its contents by redirecting it
-to a file or just piping it to `less`: `oc kustomize ceph | less`.
-
-Creating the basic secret that our samples require can be done using the
-`install_yamls` target called `input`.
-
-A complete example when we already have CRC running would be:
+For Ceph we need an extra step to deploy the Ceph cluster. In our case it will
+be a toy cluster sufficient for minor PoC tests deployed with `make ceph
+TIMEOUT=90`, instead of a user-supplied external Ceph cluster. So the steps
+are:
 
 ```
 $ cd install_yamls
 $ make ceph TIMEOUT=90
-$ make crc_storage openstack input
-$ cd ../cinder-operator
-$ oc kustomize config/samples/backends/ceph | oc apply -f -
+$ make crc_storage openstack
+$ oc kustomize ../cinder-operator/config/samples/backends/lvm/iscsi > ~/openstack-deployment.yaml
+$ export OPENSTACK_CR=`realpath ~/openstack-deployment.yaml`
+$ make openstack_deploy
 ```
 
 ## Adding new samples

--- a/config/samples/backends/README.md
+++ b/config/samples/backends/README.md
@@ -29,6 +29,9 @@ Currently available samples are:
 - NetApp ONTAP iSCSI
 - NetApp ONTAP FC
 - NetApp ONTAP NFS
+- Pure Storage iSCSI
+- Pure Storage FC
+- Pure Storage NVMe-RoCE
 
 **NOTE**: These examples are designed to be applied one at time. If you attempt
 to add a second backend by applying a second example it will result in the
@@ -68,15 +71,15 @@ If we already have a deployment working we can always use
 `oc kustomize lvm/iscsi | oc apply -f -`. from this directory to make the
 changes.
 
-Some backends, like 3PAR, require a custom container because they have external
-dependencies. So there is a need to build a specific container. In RHOSP
-vendors will provide certified containers through Red Hat's container image
-registry. For illustration and development purposes this repository provides
-samples of what a `Dockerfile` would look like for each of the vendor's. This
-`Dockerfile` will be present in the vendor's directory (e.g. `hpe/Dockerfile`),
-so we would need to build a container, make it available in a registry, and
-then provide it to the cinder operator via the `containerImage` as seen in the
-samples.
+Some backends, like 3PAR and Pure, require a custom container because they have
+external dependencies. So there is a need to build a specific container. In
+RHOSP, vendors will provide certified containers through Red Hat's container
+image registry. For illustration and development purposes this repository
+provides samples of what a `Dockerfile` would look like for each of the
+vendor's. This `Dockerfile` will be present in the vendor's directory (e.g.
+`hpe/Dockerfile` and `pure/Dockerfile`), so we would need to build a container,
+make it available in a registry, and then provide it to the cinder operator via
+the `containerImage` as seen in the samples.
 
 ## Ceph example
 

--- a/config/samples/backends/bases/nvmeof/nvme-fabrics.yaml
+++ b/config/samples/backends/bases/nvmeof/nvme-fabrics.yaml
@@ -5,14 +5,14 @@ metadata:
   labels:
     machineconfiguration.openshift.io/role: master
     service: cinder
-  name: 99-master-cinder-load-nvme-fabrics
+  name: 99-master-cinder-load-nvmeof
 spec:
   config:
     ignition:
       version: 3.2.0
     storage:
       files:
-        - path: /etc/modules-load.d/nvme_fabrics.conf
+        - path: /etc/modules-load.d/nvmeof.conf
           overwrite: false
           # Mode must be decimal, this is 0644
           mode: 420
@@ -23,4 +23,5 @@ spec:
           contents:
             # Source can be a http, https, tftp, s3, gs, or data as defined in rfc2397.
             # This is the rfc2397 text/plain string format
-            source: data:,nvme-fabrics
+            # nvme-fabrics should load other modules automatically, but load them to be sure
+            source: data:,nvme-fabrics%0Anvme-tcp%0Anvme-rdma

--- a/config/samples/backends/bases/openstack/kustomization.yaml
+++ b/config/samples/backends/bases/openstack/kustomization.yaml
@@ -1,2 +1,24 @@
 resources:
-  - openstack.yaml
+  - https://raw.githubusercontent.com/openstack-k8s-operators/openstack-operator/main/config/samples/core_v1beta1_openstackcontrolplane_galera_network_isolation.yaml
+patches:
+  # Remove existing backends so we don't end up with a volume1 useless object
+  - target:
+      kind: OpenStackControlPlane
+      name: .*
+    patch: |-
+      - op: remove
+        path: /spec/cinder/template/cinderVolumes
+  # Rename OpenStackControlPlane to "openstack", so all backend samples can use
+  # that name regardless of the name used in the source base.
+  - target:
+      kind: OpenStackControlPlane
+      name: .*
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: openstack
+  # Make our base customizations
+  - target:
+      kind: OpenStackControlPlane
+      name: .*
+    path: openstack.yaml

--- a/config/samples/backends/bases/openstack/openstack.yaml
+++ b/config/samples/backends/bases/openstack/openstack.yaml
@@ -1,69 +1,16 @@
-#  Modified version from https://github.com/openstack-k8s-operators/openstack-operator/blob/master/config/samples/core_v1beta1_openstackcontrolplane.yaml
+#  Changes to the openstack-operator base YAML
+#  Changes:
+#  - Disable Manila
+#  - Enable debug logs for Cinder
 apiVersion: core.openstack.org/v1beta1
 kind: OpenStackControlPlane
 metadata:
   name: openstack
 spec:
-  secret: osp-secret
-  storageClass: local-storage
-  keystone:
-    template:
-      databaseInstance: openstack
-      secret: osp-secret
-  mariadb:
-    templates:
-      openstack:
-        storageRequest: 500M
-  rabbitmq:
-    templates:
-      rabbitmq:
-        replicas: 1
-      rabbitmq-cell1:
-        replicas: 1
-  glance:
-    template:
-      databaseInstance: openstack
-      storageClass: ""
-      storageRequest: 2G
-      glanceAPIInternal:
-        replicas: 1
-      glanceAPIExternal:
-        replicas: 1
+  manila:
+    enabled: false
   cinder:
     template:
       customServiceConfig: |
         [DEFAULT]
         debug = true
-      cinderAPI:
-        replicas: 1
-      cinderScheduler:
-        replicas: 1
-      cinderBackup:
-        replicas: 0
-  manila:
-    enabled: false
-    template:
-      manilaShares:
-        share1:
-          replicas: 0
-  ironic:
-    enabled: false
-    template:
-      ironicConductors:
-        - replicas: 0
-  memcached:
-    enabled: false
-  galera:
-    enabled: false
-  placement:
-    enabled: false
-  ovn:
-    enabled: false
-    template:
-      ovnController:
-        external-ids:
-          ovn-encap-type: "geneve"
-  neutron:
-    enabled: false
-  nova:
-    enabled: false

--- a/config/samples/backends/bases/openstack/openstack.yaml
+++ b/config/samples/backends/bases/openstack/openstack.yaml
@@ -2,6 +2,7 @@
 #  Changes:
 #  - Disable Manila
 #  - Enable debug logs for Cinder
+#  - Enable Cinder backup using swift
 apiVersion: core.openstack.org/v1beta1
 kind: OpenStackControlPlane
 metadata:
@@ -14,3 +15,14 @@ spec:
       customServiceConfig: |
         [DEFAULT]
         debug = true
+      cinderBackup:
+        networkAttachments:
+        - storage
+        replicas: 1
+        customServiceConfig: |
+          [DEFAULT]
+          backup_driver = cinder.backup.drivers.swift.SwiftBackupDriver
+          # Below are defaults, explicit for illustration purposes
+          backup_swift_auth = per_user
+          keystone_catalog_info = identity:Identity Service:publicURL
+          swift_catalog_info = object-store:swift:publicURL

--- a/config/samples/backends/ceph/backend.yaml
+++ b/config/samples/backends/ceph/backend.yaml
@@ -29,8 +29,8 @@ spec:
     template:
       cinderVolumes:
         ceph:
-          # Once nova is enabled we need to either manually define the
-          # rbd_secret_uuid configuration option or use Antelope release.
+          networkAttachments:
+          - storage
           customServiceConfig: |
             [ceph]
             volume_backend_name=ceph

--- a/config/samples/backends/hpe/3par/fc/backend.yaml
+++ b/config/samples/backends/hpe/3par/fc/backend.yaml
@@ -1,0 +1,33 @@
+# To be able to use this sample it is necessary to:
+# - Have a 3PAR backend with FC support
+# - Have the 3PAR credentials in cinder-volume-3par-secrets.yaml
+# - Having multpathd running on the host (done by this sample)
+# - Build a cinder-volume container with the 3parclient cinder driver dependency, make it available in a registry accessible by OpenShift, and set its location in this file's containerImage
+#
+# There is a sample Dockerfile in the parent directory showing how the cinder-volume container in this containerImage was created.
+# The correct way to configure and run the daemons is using `MachineConfig` as shown in `multipathd.yaml`, like this sample does.
+#
+# ATTENTION: After applying this OpenShift nodes will reboot, because of the `MachineConfig` changes and will take a while to recover.
+
+apiVersion: core.openstack.org/v1beta1
+kind: OpenStackControlPlane
+metadata:
+  name: openstack
+spec:
+  cinder:
+    template:
+      cinderVolumes:
+        hpe3par-fc:
+          networkAttachments:
+          - storage
+          # This image exists and was built using the Dockerfile available in the grandparent directory
+          containerImage: quay.io/geguileo/podified-antelope-openstack-cinder-volume-3par:current-podified
+          customServiceConfigSecrets:
+            - cinder-volume-3par-secrets
+          customServiceConfig: |
+            [hpe3par]
+            volume_backend_name=hpe3par
+            volume_driver = cinder.volume.drivers.hpe.hpe_3par_fc.HPE3PARFCDriver
+            hpe3par_debug=False
+            hpe3par_snapshot_retention=48
+            hpe3par_snapshot_expiration=72

--- a/config/samples/backends/hpe/3par/fc/cinder-volume-3par-secrets.yaml
+++ b/config/samples/backends/hpe/3par/fc/cinder-volume-3par-secrets.yaml
@@ -1,0 +1,22 @@
+# Define the "cinder-volume-3par-secrets" Secret that contains sensitive
+# information pertaining to the [hpe3par] backend.
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    service: cinder
+    component: cinder-volume
+  name: cinder-volume-3par-secrets
+type: Opaque
+stringData:
+  hpe3par-secrets.conf: |
+    [hpe3par]
+    hpe3par_api_url=https://10.10.0.141:8080/api/v1
+    hpe3par_username=edit3par
+    hpe3par_password=3parpass
+    hpe3par_cpg=OpenStackCPG_RAID5_NL
+    san_ip=10.10.22.241
+    san_login=3paradm
+    san_password=3parpass
+    hpe3par_iscsi_ips=10.10.220.253:3261,10.10.222.234
+    hpe3par_cpg_snap=OpenStackSNAP_CPG

--- a/config/samples/backends/hpe/3par/fc/kustomization.yaml
+++ b/config/samples/backends/hpe/3par/fc/kustomization.yaml
@@ -1,0 +1,6 @@
+resources:
+  - ../../../bases/multipathd
+  - ../../../bases/openstack
+  - cinder-volume-3par-secrets.yaml
+patches:
+  - backend.yaml

--- a/config/samples/backends/hpe/3par/iscsi/backend.yaml
+++ b/config/samples/backends/hpe/3par/iscsi/backend.yaml
@@ -1,0 +1,34 @@
+# To be able to use this sample it is necessary to:
+# - Have a 3PAR backend with iSCSI support
+# - Have the 3PAR credentials in cinder-volume-3par-secrets.yaml
+# - Having iscsid and multpathd running on the host (automatically done by this sample)
+# - Build a cinder-volume container with the 3parclient cinder driver dependency, make it available in a registry accessible by OpenShift, and set its location in this file's containerImage
+#
+# There is a sample Dockerfile in the parent directory showing how the cinder-volume container in this containerImage was created.
+# The correct way to configure and run the daemons is using `MachineConfig` as shown in `iscsid.yaml` and `multipathd.yaml`, like this sample does.
+#
+# ATTENTION: After applying this OpenShift nodes will reboot, because of the `MachineConfig` changes and will take a while to recover.
+
+apiVersion: core.openstack.org/v1beta1
+kind: OpenStackControlPlane
+metadata:
+  name: openstack
+spec:
+  cinder:
+    template:
+      cinderVolumes:
+        hpe3par-iscsi:
+          networkAttachments:
+          - storage
+          # This image exists and was built using the Dockerfile available in the grandparent directory
+          containerImage: quay.io/geguileo/podified-antelope-openstack-cinder-volume-3par:current-podified
+          customServiceConfigSecrets:
+            - cinder-volume-3par-secrets
+          customServiceConfig: |
+            [hpe3par]
+            volume_backend_name=hpe3par
+            volume_driver = cinder.volume.drivers.hpe.hpe_3par_iscsi.HPE3PARISCSIDriver
+            hpe3par_debug=False
+            hpe3par_iscsi_chap_enabled=false
+            hpe3par_snapshot_retention=48
+            hpe3par_snapshot_expiration=72

--- a/config/samples/backends/hpe/3par/iscsi/cinder-volume-3par-secrets.yaml
+++ b/config/samples/backends/hpe/3par/iscsi/cinder-volume-3par-secrets.yaml
@@ -1,0 +1,22 @@
+# Define the "cinder-volume-3par-secrets" Secret that contains sensitive
+# information pertaining to the [hpe3par] backend.
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    service: cinder
+    component: cinder-volume
+  name: cinder-volume-3par-secrets
+type: Opaque
+stringData:
+  hpe3par-secrets.conf: |
+    [hpe3par]
+    hpe3par_api_url=https://10.10.0.141:8080/api/v1
+    hpe3par_username=edit3par
+    hpe3par_password=3parpass
+    hpe3par_cpg=OpenStackCPG_RAID5_NL
+    san_ip=10.10.22.241
+    san_login=3paradm
+    san_password=3parpass
+    hpe3par_iscsi_ips=10.10.220.253:3261,10.10.222.234
+    hpe3par_cpg_snap=OpenStackSNAP_CPG

--- a/config/samples/backends/hpe/3par/iscsi/kustomization.yaml
+++ b/config/samples/backends/hpe/3par/iscsi/kustomization.yaml
@@ -1,0 +1,7 @@
+resources:
+  - ../../../bases/iscsid
+  - ../../../bases/multipathd
+  - ../../../bases/openstack
+  - cinder-volume-3par-secrets.yaml
+patches:
+  - backend.yaml

--- a/config/samples/backends/hpe/Dockerfile
+++ b/config/samples/backends/hpe/Dockerfile
@@ -1,0 +1,25 @@
+# HPE 3PAR Cinder Volume container for Antelope deployments
+FROM quay.io/podified-antelope-centos9/openstack-cinder-volume:current-podified
+
+ARG min_3parclient_version=4.2.10
+MAINTAINER HPE
+
+LABEL name="geguileo/podified-antelope-openstack-cinder-volume-3par:current-podified" \
+      maintainer="HPE" \
+      vendor="HPE" \
+      version="2.0" \
+      release="Antelope" \
+      summary="OpenStack cinder-volume HPE" \
+      description="Cinder plugin for HPE 3PAR"
+
+# switch to root and install a custom RPM, etc.
+USER "root"
+
+RUN curl "https://bootstrap.pypa.io/get-pip.py" -o "get-pip.py" && \
+    python3 get-pip.py && \
+    pip3 install "python-3parclient>=${min_3parclient_version}" && \
+    rm -f get-pip.py
+
+
+# switch the container back to the default user
+USER "cinder"

--- a/config/samples/backends/lvm/iscsi/backend.yaml
+++ b/config/samples/backends/lvm/iscsi/backend.yaml
@@ -14,6 +14,8 @@ spec:
     template:
       cinderVolumes:
         lvm-iscsi:
+          networkAttachments:
+          - storage
           customServiceConfig: |
             [lvm]
             image_volume_cache_enabled=false

--- a/config/samples/backends/lvm/nvme-tcp/backend.yaml
+++ b/config/samples/backends/lvm/nvme-tcp/backend.yaml
@@ -13,6 +13,8 @@ spec:
     template:
       cinderVolumes:
         lvm-nvme-tcp:
+          networkAttachments:
+          - storage
           customServiceConfig: |
             [lvm]
             volume_backend_name=lvm_nvme_tcp

--- a/config/samples/backends/netapp/ontap/fc/backend.yaml
+++ b/config/samples/backends/netapp/ontap/fc/backend.yaml
@@ -1,0 +1,29 @@
+# To be able to use this sample it is necessary to:
+# - Have a NetApp ONTAP backend with FC support
+# - Have the NetApp storage credentials in cinder-volume-netapp-secrets.yaml
+# - Having multpathd running on the host (automatically done by this sample)
+#
+# The correct way to configure and run the daemons is using `MachineConfig` as shown in `iscsid.yaml` and `multipathd.yaml`, like this sample does.
+#
+# ATTENTION: After applying this OpenShift nodes will reboot, because of the `MachineConfig` changes and will take a while to recover.
+
+apiVersion: core.openstack.org/v1beta1
+kind: OpenStackControlPlane
+metadata:
+  name: openstack
+spec:
+  cinder:
+    template:
+      cinderVolumes:
+        ontap-fc:
+          networkAttachments:
+          - storage
+          customServiceConfigSecrets:
+            - cinder-volume-ontap-secrets
+          customServiceConfig: |
+            [ontap]
+            volume_backend_name=ontap
+            volume_driver=cinder.volume.drivers.netapp.common.NetAppDriver
+            netapp_storage_protocol=fc
+            netapp_storage_family=ontap_cluster
+            consistencygroup_support = True

--- a/config/samples/backends/netapp/ontap/fc/cinder-volume-ontap-secrets.yaml
+++ b/config/samples/backends/netapp/ontap/fc/cinder-volume-ontap-secrets.yaml
@@ -1,0 +1,18 @@
+# Define the "cinder-volume-ontap-secrets" Secret that contains sensitive
+# information pertaining to the [ontap] backend.
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    service: cinder
+    component: cinder-volume
+  name: cinder-volume-ontap-secrets
+type: Opaque
+stringData:
+  ontap-secrets.conf: |
+    [ontap]
+    netapp_login=admin_username
+    netapp_password=admin_password
+    netapp_vserver=svm_name
+    netapp_server_hostname=hostname
+    netapp_server_port=80

--- a/config/samples/backends/netapp/ontap/fc/kustomization.yaml
+++ b/config/samples/backends/netapp/ontap/fc/kustomization.yaml
@@ -1,0 +1,6 @@
+resources:
+  - ../../../bases/multipathd
+  - ../../../bases/openstack
+  - cinder-volume-ontap-secrets.yaml
+patches:
+  - backend.yaml

--- a/config/samples/backends/netapp/ontap/iscsi/backend.yaml
+++ b/config/samples/backends/netapp/ontap/iscsi/backend.yaml
@@ -1,0 +1,29 @@
+# To be able to use this sample it is necessary to:
+# - Have a NetApp ONTAP backend with iSCSI support
+# - Have the NetApp storage credentials in cinder-volume-netapp-secrets.yaml
+# - Having iscsid and multpathd running on the host (automatically done by this sample)
+#
+# The correct way to configure and run the daemons is using `MachineConfig` as shown in `iscsid.yaml` and `multipathd.yaml`, like this sample does.
+#
+# ATTENTION: After applying this OpenShift nodes will reboot, because of the `MachineConfig` changes and will take a while to recover.
+
+apiVersion: core.openstack.org/v1beta1
+kind: OpenStackControlPlane
+metadata:
+  name: openstack
+spec:
+  cinder:
+    template:
+      cinderVolumes:
+        ontap-iscsi:
+          networkAttachments:
+          - storage
+          customServiceConfigSecrets:
+            - cinder-volume-ontap-secrets
+          customServiceConfig: |
+            [ontap]
+            volume_backend_name=ontap
+            volume_driver=cinder.volume.drivers.netapp.common.NetAppDriver
+            netapp_storage_protocol=iscsi
+            netapp_storage_family=ontap_cluster
+            consistencygroup_support = True

--- a/config/samples/backends/netapp/ontap/iscsi/cinder-volume-ontap-secrets.yaml
+++ b/config/samples/backends/netapp/ontap/iscsi/cinder-volume-ontap-secrets.yaml
@@ -1,0 +1,18 @@
+# Define the "cinder-volume-ontap-secrets" Secret that contains sensitive
+# information pertaining to the [ontap] backend.
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    service: cinder
+    component: cinder-volume
+  name: cinder-volume-ontap-secrets
+type: Opaque
+stringData:
+  ontap-secrets.conf: |
+    [ontap]
+    netapp_login=admin_username
+    netapp_password=admin_password
+    netapp_vserver=svm_name
+    netapp_server_hostname=hostname
+    netapp_server_port=80

--- a/config/samples/backends/netapp/ontap/iscsi/kustomization.yaml
+++ b/config/samples/backends/netapp/ontap/iscsi/kustomization.yaml
@@ -1,0 +1,7 @@
+resources:
+  - ../../../bases/iscsid
+  - ../../../bases/multipathd
+  - ../../../bases/openstack
+  - cinder-volume-ontap-secrets.yaml
+patches:
+  - backend.yaml

--- a/config/samples/backends/netapp/ontap/nfs/backend.yaml
+++ b/config/samples/backends/netapp/ontap/nfs/backend.yaml
@@ -1,0 +1,50 @@
+# To be able to use this sample it is necessary to:
+# - Have a NetApp ONTAP backend with NFS support
+# - Have the NetApp storage credentials and NFS configuration in cinder-volume-netapp-secrets.yaml
+
+apiVersion: core.openstack.org/v1beta1
+kind: OpenStackControlPlane
+metadata:
+  name: openstack
+spec:
+  # We need to "drop" the "nfs_shares_config" file into the volume service.
+  # The contents come from a secret that we are creating in the
+  # "cinder-volume-ontap-secrets.yaml" file. This drops the secret in
+  # /etc/cinder/nfs_shares.d directory, and then the key in the secret defines
+  # the name of the file, in our case shares-config. That's why the
+  # configuration option defines that the location is
+  # /etc/cinder/nfs_shares.d/shares-config.
+  extraMounts:
+    - name: v1
+      region: r1
+      extraVol:
+        - propagation:
+          - CinderVolume
+          extraVolType: Undefined
+          volumes:
+          - name: nfs-shares
+            projected:
+              sources:
+              - secret:
+                  name: cinder-volume-ontap-shares-secrets
+          mounts:
+          - name: nfs-shares
+            mountPath: /etc/cinder/nfs_shares.d
+            readOnly: true
+  cinder:
+    template:
+      cinderVolumes:
+        ontap-iscsi:
+          networkAttachments:
+          - storage
+          customServiceConfigSecrets:
+            - cinder-volume-ontap-secrets
+          customServiceConfig: |
+            [ontap]
+            volume_backend_name=ontap
+            volume_driver=cinder.volume.drivers.netapp.common.NetAppDriver
+            netapp_server_hostname=hostname
+            netapp_server_port=80
+            netapp_storage_protocol=nfs
+            netapp_storage_family=ontap_cluster
+            nfs_shares_config=/etc/cinder/nfs_shares.d/shares-config

--- a/config/samples/backends/netapp/ontap/nfs/cinder-volume-ontap-secrets.yaml
+++ b/config/samples/backends/netapp/ontap/nfs/cinder-volume-ontap-secrets.yaml
@@ -1,0 +1,29 @@
+# Define the "cinder-volume-ontap-secrets" Secret that contains sensitive
+# information pertaining to the [iscsi] backend.
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    service: cinder
+    component: cinder-volume
+  name: cinder-volume-ontap-secrets
+type: Opaque
+stringData:
+  ontap-cinder-secrets.conf: |
+    [ontap]
+    netapp_login=admin_username
+    netapp_password=admin_password
+    netapp_vserver=svm_name
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    service: cinder
+    component: cinder-volume
+  name: cinder-volume-ontap-shares-secrets
+type: Opaque
+stringData:
+  shares-config: |
+    10.63.165.215:/nfs/test
+    10.63.165.215:/nfs2/test2

--- a/config/samples/backends/netapp/ontap/nfs/kustomization.yaml
+++ b/config/samples/backends/netapp/ontap/nfs/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+  - ../../../bases/openstack
+  - cinder-volume-ontap-secrets.yaml
+patches:
+  - backend.yaml

--- a/config/samples/backends/nfs/backend.yaml
+++ b/config/samples/backends/nfs/backend.yaml
@@ -9,6 +9,8 @@ spec:
     template:
       cinderVolumes:
         nfs:
+          networkAttachments:
+          - storage
           customServiceConfig: |
             [nfs]
             volume_backend_name=nfs

--- a/config/samples/backends/pure/Dockerfile
+++ b/config/samples/backends/pure/Dockerfile
@@ -1,0 +1,23 @@
+# Pure Storage Cinder Volume container for Antelope deployments
+
+FROM quay.io/podified-antelope-centos9/openstack-cinder-volume:current-podified
+
+ARG min_pureclient_version=1.17.0
+
+LABEL maintainer="Pure Storage" \
+      description="OpenStack cinder-volume Pure Storage" \
+      summary="OpenStack cinder-volume Pure Storage" \
+      name="geguileo/podified-antelope-openstack-cinder-volume-pure:current-podified" \
+      vendor="Pure Storage" \
+      min_pureclient="${pureclient_version}"
+
+# Switch to root to install packages
+USER root
+
+RUN curl "https://bootstrap.pypa.io/get-pip.py" -o "get-pip.py" && \
+    python3 get-pip.py && \
+    pip3 install "purestorage>=${min_pureclient_version}" && \
+    rm -f get-pip.py
+
+# Switch to cinder user
+USER cinder

--- a/config/samples/backends/pure/fc/backend.yaml
+++ b/config/samples/backends/pure/fc/backend.yaml
@@ -1,0 +1,32 @@
+# To be able to use this sample it is necessary to:
+# - Have a Pure backend with FC support
+# - Have the Pure storage credentials in cinder-volume-pure-secrets.yaml
+# - Having multpathd running on the host (done by this sample)
+# - Build a cinder-volume container with the pure cinder driver dependency, make it available in a registry accessible by OpenShift, and set its location in this file's containerImage
+#
+# There is a sample Dockerfile in the parent directory showing how the cinder-volume container in this containerImage was created.
+# The correct way to configure and run the daemons is using `MachineConfig` as shown in `multipathd.yaml`, like this samle does.
+#
+# ATTENTION: After applying this OpenShift nodes will reboot, because of the `MachineConfig` changes and will take a while to recover.
+
+apiVersion: core.openstack.org/v1beta1
+kind: OpenStackControlPlane
+metadata:
+  name: openstack
+spec:
+  cinder:
+    template:
+      cinderVolumes:
+        pure-fc:
+          networkAttachments:
+          - storage
+          # This image exists and was built using the Dockerfile available in the parent directory
+          containerImage: quay.io/geguileo/podified-antelope-openstack-cinder-volume-pure:current-podified
+          # Configuration details available at
+          # https://pure-storage-openstack-docs.readthedocs.io/en/latest/cinder/ch_cinder-configuration.html
+          customServiceConfigSecrets:
+            - cinder-volume-pure-secrets
+          customServiceConfig: |
+            [pure]
+            volume_backend_name=pure
+            volume_driver=cinder.volume.drivers.pure.PureFCDriver

--- a/config/samples/backends/pure/fc/cinder-volume-pure-secrets.yaml
+++ b/config/samples/backends/pure/fc/cinder-volume-pure-secrets.yaml
@@ -1,0 +1,15 @@
+# Define the "cinder-volume-pure-secrets" Secret that contains sensitive
+# information pertaining to the [pure] backend.
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    service: cinder
+    component: cinder-volume
+  name: cinder-volume-pure-secrets
+type: Opaque
+stringData:
+  pure-secrets.conf: |
+    [pure]
+    san_ip=192.168.1.32
+    pure_api_token=c6033033-fe69-2515-a9e8-966bb7fe4b40

--- a/config/samples/backends/pure/fc/kustomization.yaml
+++ b/config/samples/backends/pure/fc/kustomization.yaml
@@ -1,0 +1,6 @@
+resources:
+  - ../../bases/multipathd
+  - ../../bases/openstack
+  - cinder-volume-pure-secrets.yaml
+patches:
+  - backend.yaml

--- a/config/samples/backends/pure/iscsi/backend.yaml
+++ b/config/samples/backends/pure/iscsi/backend.yaml
@@ -1,0 +1,32 @@
+# To be able to use this sample it is necessary to:
+# - Have a Pure backend with iSCSI support
+# - Have the Pure storage credentials in cinder-volume-pure-secrets.yaml
+# - Having iscsid and multpathd running on the host (done by this sample)
+# - Build a cinder-volume container with the pure cinder driver dependency, make it available in a registry accessible by OpenShift, and set its location in this file's containerImage
+#
+# There is a sample Dockerfile in the parent directory showing how the cinder-volume container in this containerImage was created.
+# The correct way to configure and run the daemons is using `MachineConfig` as shown in `iscsid.yaml` and `multipathd.yaml`, like this samle does.
+#
+# ATTENTION: After applying this OpenShift nodes will reboot, because of the `MachineConfig` changes and will take a while to recover.
+
+apiVersion: core.openstack.org/v1beta1
+kind: OpenStackControlPlane
+metadata:
+  name: openstack
+spec:
+  cinder:
+    template:
+      cinderVolumes:
+        pure-iscsi:
+          networkAttachments:
+          - storage
+          # This image exists and was built using the Dockerfile available in the parent directory
+          containerImage: quay.io/geguileo/podified-antelope-openstack-cinder-volume-pure:current-podified
+          # Configuration details available at
+          # https://pure-storage-openstack-docs.readthedocs.io/en/latest/cinder/ch_cinder-configuration.html
+          customServiceConfigSecrets:
+            - cinder-volume-pure-secrets
+          customServiceConfig: |
+            [pure]
+            volume_backend_name=pure
+            volume_driver=cinder.volume.drivers.pure.PureISCSIDriver

--- a/config/samples/backends/pure/iscsi/cinder-volume-pure-secrets.yaml
+++ b/config/samples/backends/pure/iscsi/cinder-volume-pure-secrets.yaml
@@ -1,0 +1,15 @@
+# Define the "cinder-volume-pure-secrets" Secret that contains sensitive
+# information pertaining to the [pure] backend.
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    service: cinder
+    component: cinder-volume
+  name: cinder-volume-pure-secrets
+type: Opaque
+stringData:
+  pure-secrets.conf: |
+    [pure]
+    san_ip=192.168.1.32
+    pure_api_token=c6033033-fe69-2515-a9e8-966bb7fe4b40

--- a/config/samples/backends/pure/iscsi/kustomization.yaml
+++ b/config/samples/backends/pure/iscsi/kustomization.yaml
@@ -1,0 +1,7 @@
+resources:
+  - ../../bases/iscsid
+  - ../../bases/multipathd
+  - ../../bases/openstack
+  - cinder-volume-pure-secrets.yaml
+patches:
+  - backend.yaml

--- a/config/samples/backends/pure/nvme-roce/backend.yaml
+++ b/config/samples/backends/pure/nvme-roce/backend.yaml
@@ -1,0 +1,33 @@
+# To be able to use this sample it is necessary to:
+# - Have a Pure backend with NVMe-RoCE support
+# - Have the Pure storage credentials in cinder-volume-pure-secrets.yaml
+# - Having nvme-fabrics kernel module loaded on the host (done by this sample)
+# - Build a cinder-volume container with the pure cinder driver dependency, make it available in a registry accessible by OpenShift, and set its location in this file's containerImage
+#
+# There is a sample Dockerfile in the parent directory showing how the cinder-volume container in this containerImage was created.
+# The correct way to configure and run the daemons is using `MachineConfig` as shown in `nvme-fabrics.yaml`, like this sample does.
+#
+# ATTENTION: After applying this OpenShift nodes will reboot, because of the `MachineConfig` changes and will take a while to recover.
+
+apiVersion: core.openstack.org/v1beta1
+kind: OpenStackControlPlane
+metadata:
+  name: openstack
+spec:
+  cinder:
+    template:
+      cinderVolumes:
+        pure-nvme-roce:
+          networkAttachments:
+          - storage
+          # This image exists and was built using the Dockerfile available in the parent directory
+          containerImage: quay.io/geguileo/podified-antelope-openstack-cinder-volume-pure:current-podified
+          # Configuration details available at
+          # https://pure-storage-openstack-docs.readthedocs.io/en/latest/cinder/ch_cinder-configuration.html
+          customServiceConfigSecrets:
+            - cinder-volume-pure-secrets
+          customServiceConfig: |
+            [pure]
+            volume_backend_name=pure
+            volume_driver=cinder.volume.drivers.pure.PureNVMEDriver
+            pure_nvme_transport=roce

--- a/config/samples/backends/pure/nvme-roce/cinder-volume-pure-secrets.yaml
+++ b/config/samples/backends/pure/nvme-roce/cinder-volume-pure-secrets.yaml
@@ -1,0 +1,15 @@
+# Define the "cinder-volume-pure-secrets" Secret that contains sensitive
+# information pertaining to the [pure] backend.
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    service: cinder
+    component: cinder-volume
+  name: cinder-volume-pure-secrets
+type: Opaque
+stringData:
+  pure-secrets.conf: |
+    [pure]
+    san_ip=192.168.1.32
+    pure_api_token=c6033033-fe69-2515-a9e8-966bb7fe4b40

--- a/config/samples/backends/pure/nvme-roce/kustomization.yaml
+++ b/config/samples/backends/pure/nvme-roce/kustomization.yaml
@@ -1,0 +1,7 @@
+resources:
+  - ../../bases/nvmeof
+  - ../../bases/multipathd
+  - ../../bases/openstack
+  - cinder-volume-pure-secrets.yaml
+patches:
+  - backend.yaml


### PR DESCRIPTION
This PR improves the Cinder backend samples to provide samples for additional storage vendors as well as make the samples require less maintenance.

In this PR we stop having an in-tree `OpenStackControlPlane` definition and instead we reference the one from the `openstack-operator` repository. This way it will always be up to date when we run `oc kustomize`.

There are 8 new backend samples from 3 vendors (HPE, Pure, NetApp) and with 4 different transport protocols (iSCSI, FC, NFS, NVMe-TCP).