### PR TITLE
enable service token role validation for all service tokens

### DIFF
--- a/templates/cinderapi/config/01-service-defaults.conf
+++ b/templates/cinderapi/config/01-service-defaults.conf
@@ -1,2 +1,9 @@
 [DEFAULT]
 log_file = {{ .LogFile }}
+
+[keystone_authtoken]
+# This is part of hardening related to CVE-2023-2088
+# when enabled the service token user must have the service role to be considered valid.
+# cinder already checks for this, explicitly in the case of the attchment API even when
+# this is not enforced for all service token validation.
+service_token_roles_required = true


### PR DESCRIPTION
As part of adressing CVE-2023-2088 cinder was modifed to
require the service role to be present in service token when
calling the attachemtn api to modify attachments related to nova
instance. One recomendation of that CVE mitigration discussions
was that all services shoudl enabel the service token role validation
by default. This change simplely enabled that by setting
[keystone_authtoken]/service_token_roles_required = true

Related: OSPRH191
