### PR TITLE
Enable file watching for GMR

### DIFF
--- a/templates/cinder/config/00-global-defaults.conf
+++ b/templates/cinder/config/00-global-defaults.conf
@@ -52,6 +52,9 @@ heartbeat_timeout_threshold=60
 [oslo_middleware]
 enable_proxy_headers_parsing=True
 
+[oslo_reports]
+file_event_handler=/etc/cinder
+
 [keystone_authtoken]
 www_authenticate_uri={{ .KeystonePublicURL }}
 auth_url = {{ .KeystoneInternalURL }}


### PR DESCRIPTION
Guru Meditation Reports [1] supports triggering the reports via signal or file watch, the default being using a signal.

Usually the PID for the service in a container is 1, so it's easy to trigger the report.

The problem for Cinder in OpenShift is that the backup and volume services share the PID with the host (to use `nsenter`) so it's no longer 1, and we don't which PID it is.

So to make it easier we just configure oslo reports to watch /etc/cinder, and then the openstack-must-gather can just `touch /etc/cinder` to trigger the report in the logs.

We use `/etc/cinder` instead of something like an empty file like `/etc/cinder/gmr` because the file needs to exist to be watched, so we would need to create this file ourselves, which would be more cumbersome.

[1]: https://github.com/openstack/oslo.reports