### PR TITLE
Use database helpers from mariadb-operator/api

### DIFF
--- a/controllers/cinder_controller.go
+++ b/controllers/cinder_controller.go
@@ -48,7 +48,6 @@ import (
 	common_rbac "github.com/openstack-k8s-operators/lib-common/modules/common/rbac"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/secret"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
-	"github.com/openstack-k8s-operators/lib-common/modules/database"
 	mariadbv1 "github.com/openstack-k8s-operators/mariadb-operator/api/v1beta1"
 
 	batchv1 "k8s.io/api/batch/v1"
@@ -281,7 +280,7 @@ func (r *CinderReconciler) reconcileDelete(ctx context.Context, instance *cinder
 	r.Log.Info(fmt.Sprintf("Reconciling Service '%s' delete", instance.Name))
 
 	// remove db finalizer first
-	db, err := database.GetDatabaseByName(ctx, helper, instance.Name)
+	db, err := mariadbv1.GetDatabaseByName(ctx, helper, instance.Name)
 	if err != nil && !k8s_errors.IsNotFound(err) {
 		return ctrl.Result{}, err
 	}
@@ -335,7 +334,7 @@ func (r *CinderReconciler) reconcileInit(
 	//
 	// create service DB instance
 	//
-	db := database.NewDatabase(
+	db := mariadbv1.NewDatabase(
 		instance.Name,
 		instance.Spec.DatabaseUser,
 		instance.Spec.Secret,

--- a/go.mod
+++ b/go.mod
@@ -11,9 +11,8 @@ require (
 	github.com/openstack-k8s-operators/infra-operator/apis v0.1.1-0.20231001103054-f74a88ed4971
 	github.com/openstack-k8s-operators/keystone-operator/api v0.1.1-0.20231001084639-804f0f7cc39a
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.1.1-0.20231001084618-12369665b166
-	github.com/openstack-k8s-operators/lib-common/modules/database v0.1.1-0.20231001084618-12369665b166
 	github.com/openstack-k8s-operators/lib-common/modules/storage v0.1.1-0.20231001084618-12369665b166
-	github.com/openstack-k8s-operators/mariadb-operator/api v0.1.1-0.20230928152002-65395552e015
+	github.com/openstack-k8s-operators/mariadb-operator/api v0.3.0
 	k8s.io/api v0.26.9
 	k8s.io/apimachinery v0.26.9
 	k8s.io/client-go v0.26.9

--- a/go.sum
+++ b/go.sum
@@ -240,14 +240,12 @@ github.com/openstack-k8s-operators/keystone-operator/api v0.1.1-0.20231001084639
 github.com/openstack-k8s-operators/keystone-operator/api v0.1.1-0.20231001084639-804f0f7cc39a/go.mod h1:eE+xBfmNourpsLpJHVCWE/BaEExFFYCKXgZqnSpTxXo=
 github.com/openstack-k8s-operators/lib-common/modules/common v0.1.1-0.20231001084618-12369665b166 h1:pZPl9njjTchHSFf2OSuzyRxrRW8LLb1OscPxVNoATrk=
 github.com/openstack-k8s-operators/lib-common/modules/common v0.1.1-0.20231001084618-12369665b166/go.mod h1:Ozg6SxfwOtMkiH553c0XQBWuygZQq4jDQCpR4hZqlxM=
-github.com/openstack-k8s-operators/lib-common/modules/database v0.1.1-0.20231001084618-12369665b166 h1:63I4+qBYwm0Q2txAZRfJ2TRo5HyBJwHxDYSpOr+jOOo=
-github.com/openstack-k8s-operators/lib-common/modules/database v0.1.1-0.20231001084618-12369665b166/go.mod h1:RroLfB6Wstc+z7JVJY9o+6YPu+wBIzTAAfMpwhv7pDI=
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.1.1-0.20231001084618-12369665b166 h1:zOnRGMdgq2XvOCCtF1lY4tFhKx3jXrcrtOiZZ1PR6M8=
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.1.1-0.20231001084618-12369665b166/go.mod h1:LOXXvTQCwhOBNd+0FTlgllpa3wqlkI6Vf3Q5QVRVPlw=
 github.com/openstack-k8s-operators/lib-common/modules/storage v0.1.1-0.20231001084618-12369665b166 h1:cfL2xCqGTcwwo57ymxY2H89xQF1KhjvjB82cf+GViWM=
 github.com/openstack-k8s-operators/lib-common/modules/storage v0.1.1-0.20231001084618-12369665b166/go.mod h1:qkK/2JzIGOzoctfe0sbL+mSelrEmErAND4vuj1qTU/A=
-github.com/openstack-k8s-operators/mariadb-operator/api v0.1.1-0.20230928152002-65395552e015 h1:1G37nuB9C8QPp7tScEpwbR7eQj+2e6l089MNzj5cChk=
-github.com/openstack-k8s-operators/mariadb-operator/api v0.1.1-0.20230928152002-65395552e015/go.mod h1:xhiz5wFdKWwVM7BF/VYon4TT3NuUPXp/Pyn2hWcp0CE=
+github.com/openstack-k8s-operators/mariadb-operator/api v0.3.0 h1:FB0xB6whYM6W4XIncYo2mPiOJWkFsIOWtCT+UOtvOaQ=
+github.com/openstack-k8s-operators/mariadb-operator/api v0.3.0/go.mod h1:xhiz5wFdKWwVM7BF/VYon4TT3NuUPXp/Pyn2hWcp0CE=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=


### PR DESCRIPTION
The lib-common/modules/database is moved to mariadb-operator/api to remove a circular dependency.