### PR TITLE
Fix LVM iSCSI target IP addresses

### DIFF
--- a/controllers/cindervolume_controller.go
+++ b/controllers/cindervolume_controller.go
@@ -581,17 +581,19 @@ func (r *CinderVolumeReconciler) generateServiceConfigs(
 
 	templateParameters := make(map[string]interface{})
 	if usesLVM {
+		// Configure 'target_secondary_ip_addresses' using addresses in the
+		// network attachments. This relies on the fact that the LVM backend
+		// can only have one replica.
+		//
+		// Do not configure the primary 'target_ip_address', so that it will default
+		// to the service's 'my_ip' address. This will be the dynamically assigned
+		// OpenShift SDN address, which allows control plane services like g-api and
+		// c-bak to connect to LVM volumes.
 		networkAttachmentAddrs := cinder.GetNetworkAttachmentAddrs(
 			instance.Namespace, instance.Spec.NetworkAttachments, instance.Status.NetworkAttachments)
 
-		// Configure target IP addresses using all addresses in the network
-		// attachments. This relies on the fact that the LVM backend can only
-		// have one replica.
 		if len(networkAttachmentAddrs) > 0 {
-			templateParameters["TargetIpAddress"] = networkAttachmentAddrs[0]
-			if len(networkAttachmentAddrs) > 1 {
-				templateParameters["TargetSecondaryIpAddresses"] = strings.Join(networkAttachmentAddrs[1:], ",")
-			}
+			templateParameters["TargetSecondaryIpAddresses"] = strings.Join(networkAttachmentAddrs, ",")
 		}
 	}
 


### PR DESCRIPTION
When configuring the LVM backend, use the external NAD status to configure the 'target_secondary_ip_addresses' but do NOT configure the primary 'target_ip_address'. This causes the cinder-volume service to fall back to using its 'my_ip' for the primary address, which will be the one assigned to it on the OpenShift SDN.

The reason for doing this is that control plane services such as cinder-backup and glance-api and are unable to reach the LVM iSCSI target on external NAD addresses such as the 'storage' network. They can, however, reach the iSCSI target via the OpenShift SDN.

This is not a perfect solution, but is adequate for a PoC using the LVM backend. EDPM compute nodes will access the iSCSI target via the 'storage' network, and c-bak and g-api will reach it via the OpenShift SDN. This requires EDPM nodes use multipath, which is OK because multipath is deployed by default.