### PR TITLE
Remove unused 'DeploymentReady' condition from Cinder status

### DIFF
--- a/controllers/cinder_controller.go
+++ b/controllers/cinder_controller.go
@@ -183,7 +183,6 @@ func (r *CinderReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 			condition.UnknownCondition(cinderv1beta1.CinderSchedulerReadyCondition, condition.InitReason, cinderv1beta1.CinderSchedulerReadyInitMessage),
 			condition.UnknownCondition(cinderv1beta1.CinderBackupReadyCondition, condition.InitReason, cinderv1beta1.CinderBackupReadyInitMessage),
 			condition.UnknownCondition(cinderv1beta1.CinderVolumeReadyCondition, condition.InitReason, cinderv1beta1.CinderVolumeReadyInitMessage),
-			condition.UnknownCondition(condition.DeploymentReadyCondition, condition.InitReason, condition.DeploymentReadyInitMessage),
 			condition.UnknownCondition(condition.NetworkAttachmentsReadyCondition, condition.InitReason, condition.NetworkAttachmentsReadyInitMessage),
 			// service account, role, rolebinding conditions
 			condition.UnknownCondition(condition.ServiceAccountReadyCondition, condition.InitReason, condition.ServiceAccountReadyInitMessage),

--- a/test/functional/cinder_controller_test.go
+++ b/test/functional/cinder_controller_test.go
@@ -44,7 +44,7 @@ var _ = Describe("Cinder controller", func() {
 		It("initializes the status fields", func() {
 			Eventually(func(g Gomega) {
 				cinder := GetCinder(cinderName)
-				g.Expect(cinder.Status.Conditions).To(HaveLen(16))
+				g.Expect(cinder.Status.Conditions).To(HaveLen(15))
 
 				g.Expect(cinder.Status.DatabaseHostname).To(Equal(""))
 			}, timeout*2, interval).Should(Succeed())


### PR DESCRIPTION
The `DeploymentReadyCondition` condition in the Cinder controller is initialized but then never used.  It doesn't interfere with the overall "ready" state calculation because of the way the `Cinder` CRD's `IsReady()` function is written.  But if it isn't used, we should just drop it.