### PR TITLE
Configure barbican access

### DIFF
--- a/templates/cinder/config/00-global-defaults.conf
+++ b/templates/cinder/config/00-global-defaults.conf
@@ -30,6 +30,10 @@ osapi_volume_workers = 4
 control_exchange = openstack
 api_paste_config = /etc/cinder/api-paste.ini
 
+[barbican]
+auth_endpoint = {{ .KeystoneInternalURL }}
+barbican_endpoint_type = internal
+
 [database]
 connection = {{ .DatabaseConnection }}
 max_retries = -1


### PR DESCRIPTION
Add the [barbican] settings so that all cinder services can access barbican via its internal endpoint. Barbican is already the default key manager.

Jira: [OSPRH-1376](https://issues.redhat.com//browse/OSPRH-1376)