### PR TITLE
Switch cinder-api to a statefulset

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -30,18 +30,6 @@ rules:
 - apiGroups:
   - apps
   resources:
-  - deployments
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - apps
-  resources:
   - statefulsets
   verbs:
   - create

--- a/test/functional/cinder_controller_test.go
+++ b/test/functional/cinder_controller_test.go
@@ -385,7 +385,7 @@ var _ = Describe("Cinder controller", func() {
 			keystone.SimulateKeystoneServiceReady(cinderTest.CinderKeystoneService)
 		})
 		It("Check the resulting endpoints of the generated sub-CRs", func() {
-			th.SimulateDeploymentReadyWithPods(
+			th.SimulateStatefulSetReplicaReadyWithPods(
 				cinderTest.CinderAPI,
 				map[string][]string{cinderName.Namespace + "/internalapi": {"10.0.0.1"}},
 			)

--- a/test/kuttl/common/assert_sample_deployment.yaml
+++ b/test/kuttl/common/assert_sample_deployment.yaml
@@ -21,7 +21,7 @@ spec:
       replicas: 1
 ---
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: cinder-api
   ownerReferences:
@@ -31,18 +31,13 @@ metadata:
     kind: CinderAPI
     name: cinder-api
 spec:
-  progressDeadlineSeconds: 600
+  podManagementPolicy: OrderedReady
   replicas: 1
   revisionHistoryLimit: 10
   selector:
     matchLabels:
       component: cinder-api
       service: cinder
-  strategy:
-    rollingUpdate:
-      maxSurge: 25%
-      maxUnavailable: 25%
-    type: RollingUpdate
   template:
     metadata:
       creationTimestamp: null
@@ -162,6 +157,10 @@ spec:
         name: config-data-custom
       - emptyDir: {}
         name: logs
+  updateStrategy:
+    rollingUpdate:
+      partition: 0
+    type: RollingUpdate
 status:
   availableReplicas: 1
   replicas: 1


### PR DESCRIPTION
Change cinder-api from a deployment to a statefulset. Although the service doesn't require preserving stateful data, it helps with the pod naming convention so they're similar to glance-api pods, and eliminates the squirrely suffixes like "cinder-api-xzkpl"