### PR TITLE
Move -log sidecar container to dumb-init

### DIFF
--- a/pkg/cinderapi/deployment.go
+++ b/pkg/cinderapi/deployment.go
@@ -104,9 +104,16 @@ func Deployment(
 						{
 							Name: instance.Name + "-log",
 							Command: []string{
-								"/bin/bash",
+								"/usr/bin/dumb-init",
 							},
-							Args:  []string{"-c", "tail -n+1 -F " + LogFile},
+							Args: []string{
+								"--single-child",
+								"--",
+								"/usr/bin/tail",
+								"-n+1",
+								"-F",
+								LogFile,
+							},
 							Image: instance.Spec.ContainerImage,
 							SecurityContext: &corev1.SecurityContext{
 								RunAsUser: &runAsUser,

--- a/test/kuttl/common/assert_sample_deployment.yaml
+++ b/test/kuttl/common/assert_sample_deployment.yaml
@@ -64,10 +64,14 @@ spec:
             weight: 1
       containers:
       - args:
-        - -c
-        - tail -n+1 -F /var/log/cinder/cinder-api.log
+        - --single-child
+        - --
+        - /usr/bin/tail
+        - -n+1
+        - -F
+        - /var/log/cinder/cinder-api.log
         command:
-        - /bin/bash
+        - /usr/bin/dumb-init
         imagePullPolicy: IfNotPresent
         resources: {}
         securityContext:


### PR DESCRIPTION
As noticed in other operators, the -log sidecar ignores SIGTERM on delete. This patch moves the cinder-operator to the dumb-init usage to make sure the SIGTERM is handled properly by the sidecar.

Fixes: [OSPRH-770](https://issues.redhat.com//browse/OSPRH-770)