### PR TITLE
Fix our backend samples

### DIFF
--- a/config/samples/backends/ceph/kustomization.yaml
+++ b/config/samples/backends/ceph/kustomization.yaml
@@ -1,4 +1,4 @@
 resources:
   - ../bases/openstack
 patches:
-  - backend.yaml
+  - path: backend.yaml

--- a/config/samples/backends/hpe/3par/fc/kustomization.yaml
+++ b/config/samples/backends/hpe/3par/fc/kustomization.yaml
@@ -3,4 +3,4 @@ resources:
   - ../../../bases/openstack
   - cinder-volume-3par-secrets.yaml
 patches:
-  - backend.yaml
+  - path: backend.yaml

--- a/config/samples/backends/hpe/3par/iscsi/kustomization.yaml
+++ b/config/samples/backends/hpe/3par/iscsi/kustomization.yaml
@@ -4,4 +4,4 @@ resources:
   - ../../../bases/openstack
   - cinder-volume-3par-secrets.yaml
 patches:
-  - backend.yaml
+  - path: backend.yaml

--- a/config/samples/backends/lvm/iscsi/kustomization.yaml
+++ b/config/samples/backends/lvm/iscsi/kustomization.yaml
@@ -4,4 +4,4 @@ resources:
   - ../../bases/lvm
   - ../../bases/openstack
 patches:
-  - backend.yaml
+  - path: backend.yaml

--- a/config/samples/backends/lvm/nvme-tcp/kustomization.yaml
+++ b/config/samples/backends/lvm/nvme-tcp/kustomization.yaml
@@ -3,4 +3,4 @@ resources:
   - ../../bases/lvm
   - ../../bases/openstack
 patches:
-  - backend.yaml
+  - path: backend.yaml

--- a/config/samples/backends/netapp/ontap/fc/kustomization.yaml
+++ b/config/samples/backends/netapp/ontap/fc/kustomization.yaml
@@ -3,4 +3,4 @@ resources:
   - ../../../bases/openstack
   - cinder-volume-ontap-secrets.yaml
 patches:
-  - backend.yaml
+  - path: backend.yaml

--- a/config/samples/backends/netapp/ontap/iscsi/kustomization.yaml
+++ b/config/samples/backends/netapp/ontap/iscsi/kustomization.yaml
@@ -4,4 +4,4 @@ resources:
   - ../../../bases/openstack
   - cinder-volume-ontap-secrets.yaml
 patches:
-  - backend.yaml
+  - path: backend.yaml

--- a/config/samples/backends/netapp/ontap/nfs/kustomization.yaml
+++ b/config/samples/backends/netapp/ontap/nfs/kustomization.yaml
@@ -2,4 +2,4 @@ resources:
   - ../../../bases/openstack
   - cinder-volume-ontap-secrets.yaml
 patches:
-  - backend.yaml
+  - path: backend.yaml

--- a/config/samples/backends/nfs/kustomization.yaml
+++ b/config/samples/backends/nfs/kustomization.yaml
@@ -2,4 +2,4 @@ resources:
   - cinder-volume-nfs-secrets.yaml
   - ../bases/openstack
 patches:
-  - backend.yaml
+  - path: backend.yaml

--- a/config/samples/backends/pure/fc/kustomization.yaml
+++ b/config/samples/backends/pure/fc/kustomization.yaml
@@ -3,4 +3,4 @@ resources:
   - ../../bases/openstack
   - cinder-volume-pure-secrets.yaml
 patches:
-  - backend.yaml
+  - path: backend.yaml

--- a/config/samples/backends/pure/iscsi/kustomization.yaml
+++ b/config/samples/backends/pure/iscsi/kustomization.yaml
@@ -4,4 +4,4 @@ resources:
   - ../../bases/openstack
   - cinder-volume-pure-secrets.yaml
 patches:
-  - backend.yaml
+  - path: backend.yaml

--- a/config/samples/backends/pure/nvme-roce/kustomization.yaml
+++ b/config/samples/backends/pure/nvme-roce/kustomization.yaml
@@ -4,4 +4,4 @@ resources:
   - ../../bases/openstack
   - cinder-volume-pure-secrets.yaml
 patches:
-  - backend.yaml
+  - path: backend.yaml


### PR DESCRIPTION
Our backend samples no longer work on OCP 4.14 and they fail the `oc kustomize` call with:

 error: invalid Kustomization: json: cannot unmarshal string into Go
 struct field Kustomization.patches of type types.Patch

In this patch we update the `patches` section from:
```
 patches:
   - backend
```
to
```
 patches:
   - path: backend
```