### PR TITLE
Enable SRBAC by default

### DIFF
--- a/templates/cinderapi/config/01-service-defaults.conf
+++ b/templates/cinderapi/config/01-service-defaults.conf
@@ -1,2 +1,6 @@
 [DEFAULT]
 log_file = {{ .LogFile }}
+
+[oslo_policy]
+enforce_scope = true
+enforce_new_defaults = true


### PR DESCRIPTION
This patch enables SRBAC by default instead of requiring explicit enabling like we did in OSP17.

Only the API service will include the configuration since policies are to be checked at the endpoint in Cinder API.

Jira: [OSPRH-3281](https://issues.redhat.com//browse/OSPRH-3281)