### PR TITLE
Backend Samples: place on worker nodes

### DIFF
--- a/config/samples/backends/bases/iscsid/iscsid.yaml
+++ b/config/samples/backends/bases/iscsid/iscsid.yaml
@@ -2,9 +2,9 @@ apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:
   labels:
-    machineconfiguration.openshift.io/role: master
+    machineconfiguration.openshift.io/role: worker
     service: cinder
-  name: 99-master-cinder-enable-iscsid
+  name: 99-worker-cinder-enable-iscsid
 spec:
   config:
     ignition:

--- a/config/samples/backends/bases/lvm/lvm.yaml
+++ b/config/samples/backends/bases/lvm/lvm.yaml
@@ -2,10 +2,10 @@ apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:
   labels:
-    machineconfiguration.openshift.io/role: master
+    machineconfiguration.openshift.io/role: worker
     service: cinder
     component: cinder-volume
-  name: 99-master-cinder-lvm-losetup
+  name: 99-worker-cinder-lvm-losetup
 spec:
   config:
     ignition:

--- a/config/samples/backends/bases/multipathd/multipathd.yaml
+++ b/config/samples/backends/bases/multipathd/multipathd.yaml
@@ -3,9 +3,9 @@ apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:
   labels:
-    machineconfiguration.openshift.io/role: master
+    machineconfiguration.openshift.io/role: worker
     service: cinder
-  name: 99-master-cinder-enable-multipathd
+  name: 99-worker-cinder-enable-multipathd
 spec:
   config:
     ignition:

--- a/config/samples/backends/bases/nvmeof/nvme-fabrics.yaml
+++ b/config/samples/backends/bases/nvmeof/nvme-fabrics.yaml
@@ -3,9 +3,9 @@ apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:
   labels:
-    machineconfiguration.openshift.io/role: master
+    machineconfiguration.openshift.io/role: worker
     service: cinder
-  name: 99-master-cinder-load-nvmeof
+  name: 99-worker-cinder-load-nvmeof
 spec:
   config:
     ignition:


### PR DESCRIPTION
The current samples are deploying MachineConfigs on master nodes, which works just fine because right now all our master nodes are also worker nodes, but is not technically correct.

This patch updates the MachineConfigs to deploy on worker nodes, which is the technically correct location.