### PR TITLE
Revert "Backend Samples: place on worker nodes"

### DIFF
--- a/config/samples/backends/bases/iscsid/iscsid.yaml
+++ b/config/samples/backends/bases/iscsid/iscsid.yaml
@@ -2,9 +2,9 @@ apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:
   labels:
-    machineconfiguration.openshift.io/role: worker
+    machineconfiguration.openshift.io/role: master
     service: cinder
-  name: 99-worker-cinder-enable-iscsid
+  name: 99-master-cinder-enable-iscsid
 spec:
   config:
     ignition:

--- a/config/samples/backends/bases/lvm/lvm.yaml
+++ b/config/samples/backends/bases/lvm/lvm.yaml
@@ -2,10 +2,10 @@ apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:
   labels:
-    machineconfiguration.openshift.io/role: worker
+    machineconfiguration.openshift.io/role: master
     service: cinder
     component: cinder-volume
-  name: 99-worker-cinder-lvm-losetup
+  name: 99-master-cinder-lvm-losetup
 spec:
   config:
     ignition:

--- a/config/samples/backends/bases/multipathd/multipathd.yaml
+++ b/config/samples/backends/bases/multipathd/multipathd.yaml
@@ -3,9 +3,9 @@ apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:
   labels:
-    machineconfiguration.openshift.io/role: worker
+    machineconfiguration.openshift.io/role: master
     service: cinder
-  name: 99-worker-cinder-enable-multipathd
+  name: 99-master-cinder-enable-multipathd
 spec:
   config:
     ignition:

--- a/config/samples/backends/bases/nvmeof/nvme-fabrics.yaml
+++ b/config/samples/backends/bases/nvmeof/nvme-fabrics.yaml
@@ -3,9 +3,9 @@ apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:
   labels:
-    machineconfiguration.openshift.io/role: worker
+    machineconfiguration.openshift.io/role: master
     service: cinder
-  name: 99-worker-cinder-load-nvmeof
+  name: 99-master-cinder-load-nvmeof
 spec:
   config:
     ignition:


### PR DESCRIPTION
This reverts commit 9ef753e8bc1f27c7f1a4bcd7dc58255e1c62c787, where we tried to pin the `MachineConfig` to the `worker` role, because they don't work.

Even if the OpenShift CRC node has both master and worker roles, that doesn't mean that we can use them for the `MachineConfig`, because the thing that ties together a `MachineConfig` to a `Machine` is the `MachineConfigPool` and a `Machine` can only belong to one `MachineConfigPool`.

And looking at the available `Machine` in a CRC deployment we see that it has the master role.

```
Name:         crc-ksq4m-master-0
Namespace:    openshift-machine-api
Labels:       machine.openshift.io/cluster-api-cluster=crc-ksq4m
              machine.openshift.io/cluster-api-machine-role=master
              machine.openshift.io/cluster-api-machine-type=master
```

And looking at the `MachineConfigPool` we see that only the `master` pool has machine assigned to it.

```
NAME     CONFIG                                             UPDATED   UPDATING   DEGRADED   MACHINECOUNT   READYMACHINECOUNT   UPDATEDMACHINECOUNT   DEGRADEDMACHINECOUNT   AGE
master   rendered-master-e542525f4afc269344cc5e648a41f812   True      False      False      1              1                   1                     0                      34d
worker   rendered-worker-c36181deab728b3d19199b5b7dd30332   True      False      False      0              0                   0                     0                      34d
```