### PR TITLE
Bump golangci-lint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -7,12 +7,5 @@ linters:
     - ginkgolinter
     - gofmt
     - govet
-linters-settings:
-  revive:
-    rules:
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unused-parameter
-      - name: unused-parameter
-        severity: warning
-        disabled: true
 run:
   timeout: 5m

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/golangci/golangci-lint
-  rev: v1.52.2
+  rev: v1.55.2
   hooks:
     - id: golangci-lint
       args: ["-v"]


### PR DESCRIPTION
Bump the golangci-lint version to the newest that still supports 1.20 and removed disabled checks that passing now.