### PR TITLE
migrate from databaseUsername to databaseAccount and fully use MariaDBAccount

### DIFF
--- a/api/bases/cinder.openstack.org_cinderapis.yaml
+++ b/api/bases/cinder.openstack.org_cinderapis.yaml
@@ -48,10 +48,10 @@ spec:
                 items:
                   type: string
                 type: array
-              databaseHostname:
-                type: string
-              databaseUser:
+              databaseAccount:
                 default: cinder
+                type: string
+              databaseHostname:
                 type: string
               extraMounts:
                 items:
@@ -870,12 +870,8 @@ spec:
                 type: object
               passwordSelectors:
                 default:
-                  database: CinderDatabasePassword
                   service: CinderPassword
                 properties:
-                  database:
-                    default: CinderDatabasePassword
-                    type: string
                   service:
                     default: CinderPassword
                     type: string

--- a/api/bases/cinder.openstack.org_cinderbackups.yaml
+++ b/api/bases/cinder.openstack.org_cinderbackups.yaml
@@ -48,10 +48,10 @@ spec:
                 items:
                   type: string
                 type: array
-              databaseHostname:
-                type: string
-              databaseUser:
+              databaseAccount:
                 default: cinder
+                type: string
+              databaseHostname:
                 type: string
               extraMounts:
                 items:
@@ -819,12 +819,8 @@ spec:
                 type: object
               passwordSelectors:
                 default:
-                  database: CinderDatabasePassword
                   service: CinderPassword
                 properties:
-                  database:
-                    default: CinderDatabasePassword
-                    type: string
                   service:
                     default: CinderPassword
                     type: string

--- a/api/bases/cinder.openstack.org_cinders.yaml
+++ b/api/bases/cinder.openstack.org_cinders.yaml
@@ -338,10 +338,10 @@ spec:
                 type: object
               customServiceConfig:
                 type: string
-              databaseInstance:
-                type: string
-              databaseUser:
+              databaseAccount:
                 default: cinder
+                type: string
+              databaseInstance:
                 type: string
               dbPurge:
                 properties:
@@ -1124,12 +1124,8 @@ spec:
                 type: object
               passwordSelectors:
                 default:
-                  database: CinderDatabasePassword
                   service: CinderPassword
                 properties:
-                  database:
-                    default: CinderDatabasePassword
-                    type: string
                   service:
                     default: CinderPassword
                     type: string

--- a/api/bases/cinder.openstack.org_cinderschedulers.yaml
+++ b/api/bases/cinder.openstack.org_cinderschedulers.yaml
@@ -48,10 +48,10 @@ spec:
                 items:
                   type: string
                 type: array
-              databaseHostname:
-                type: string
-              databaseUser:
+              databaseAccount:
                 default: cinder
+                type: string
+              databaseHostname:
                 type: string
               extraMounts:
                 items:
@@ -819,12 +819,8 @@ spec:
                 type: object
               passwordSelectors:
                 default:
-                  database: CinderDatabasePassword
                   service: CinderPassword
                 properties:
-                  database:
-                    default: CinderDatabasePassword
-                    type: string
                   service:
                     default: CinderPassword
                     type: string

--- a/api/bases/cinder.openstack.org_cindervolumes.yaml
+++ b/api/bases/cinder.openstack.org_cindervolumes.yaml
@@ -48,10 +48,10 @@ spec:
                 items:
                   type: string
                 type: array
-              databaseHostname:
-                type: string
-              databaseUser:
+              databaseAccount:
                 default: cinder
+                type: string
+              databaseHostname:
                 type: string
               extraMounts:
                 items:
@@ -819,12 +819,8 @@ spec:
                 type: object
               passwordSelectors:
                 default:
-                  database: CinderDatabasePassword
                   service: CinderPassword
                 properties:
-                  database:
-                    default: CinderDatabasePassword
-                    type: string
                   service:
                     default: CinderPassword
                     type: string

--- a/api/go.mod
+++ b/api/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/onsi/ginkgo/v2 v2.15.0 // indirect
+	github.com/onsi/gomega v1.31.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.16.0 // indirect
 	github.com/prometheus/client_model v0.4.0 // indirect

--- a/api/go.sum
+++ b/api/go.sum
@@ -73,7 +73,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/onsi/ginkgo/v2 v2.15.0 h1:79HwNRBAZHOEwrczrgSOPy+eFTTlIGELKy5as+ClttY=
 github.com/onsi/ginkgo/v2 v2.15.0/go.mod h1:HlxMHtYF57y6Dpf+mc5529KKmSq9h2FpCF+/ZkwUxKM=
-github.com/onsi/gomega v1.30.0 h1:hvMK7xYz4D3HapigLTeGdId/NcfQx1VHMJc60ew99+8=
+github.com/onsi/gomega v1.31.1 h1:KYppCUK+bUgAZwHOu7EXVBKyQA6ILvOESHkn/tgoqvo=
+github.com/onsi/gomega v1.31.1/go.mod h1:y40C95dwAD1Nz36SsEnxvfFe8FFfNxzI5eJ0EYGyAy0=
 github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240216173409-86913e6d5885 h1:o7KZaxKt8Dr97ZJIBPW0P482gLyFEURKF89fizcJCBQ=
 github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240216173409-86913e6d5885/go.mod h1:bQwzyQtWCR9F0+IvWZ30J9d1lB6tcX3CNJ0Ten1smDw=
 github.com/openstack-k8s-operators/lib-common/modules/storage v0.3.1-0.20240216173409-86913e6d5885 h1:sMO+IYsZ91Nho0FV6y03J0NTGd8+ZWB4KmKJJU94gTU=

--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -29,17 +29,16 @@ type CinderTemplate struct {
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=cinder
-	// DatabaseUser - optional username used for cinder DB, defaults to cinder
-	// TODO: -> implement needs work in mariadb-operator, right now only cinder
-	DatabaseUser string `json:"databaseUser"`
+	// DatabaseAccount - optional MariaDBAccount used for cinder DB, defaults to cinder
+	DatabaseAccount string `json:"databaseAccount"`
 
 	// +kubebuilder:validation:Required
-	// Secret containing OpenStack password information for CinderDatabasePassword
+	// Secret containing OpenStack password information
 	Secret string `json:"secret"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default={database: CinderDatabasePassword, service: CinderPassword}
-	// PasswordSelectors - Selectors to identify the DB and ServiceUser password from the Secret
+	// +kubebuilder:default={service: CinderPassword}
+	// PasswordSelectors - Selectors to identify the ServiceUser password from the Secret
 	PasswordSelectors PasswordSelector `json:"passwordSelectors"`
 }
 
@@ -79,11 +78,6 @@ type CinderServiceTemplate struct {
 
 // PasswordSelector to identify the DB and AdminUser password from the Secret
 type PasswordSelector struct {
-	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="CinderDatabasePassword"
-	// Database - Selector to get the cinder database user password from the Secret
-	// TODO: not used, need change in mariadb-operator
-	Database string `json:"database"`
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default="CinderPassword"
 	// Service - Selector to get the cinder service password from the Secret

--- a/config/crd/bases/cinder.openstack.org_cinderapis.yaml
+++ b/config/crd/bases/cinder.openstack.org_cinderapis.yaml
@@ -48,10 +48,10 @@ spec:
                 items:
                   type: string
                 type: array
-              databaseHostname:
-                type: string
-              databaseUser:
+              databaseAccount:
                 default: cinder
+                type: string
+              databaseHostname:
                 type: string
               extraMounts:
                 items:
@@ -870,12 +870,8 @@ spec:
                 type: object
               passwordSelectors:
                 default:
-                  database: CinderDatabasePassword
                   service: CinderPassword
                 properties:
-                  database:
-                    default: CinderDatabasePassword
-                    type: string
                   service:
                     default: CinderPassword
                     type: string

--- a/config/crd/bases/cinder.openstack.org_cinderbackups.yaml
+++ b/config/crd/bases/cinder.openstack.org_cinderbackups.yaml
@@ -48,10 +48,10 @@ spec:
                 items:
                   type: string
                 type: array
-              databaseHostname:
-                type: string
-              databaseUser:
+              databaseAccount:
                 default: cinder
+                type: string
+              databaseHostname:
                 type: string
               extraMounts:
                 items:
@@ -819,12 +819,8 @@ spec:
                 type: object
               passwordSelectors:
                 default:
-                  database: CinderDatabasePassword
                   service: CinderPassword
                 properties:
-                  database:
-                    default: CinderDatabasePassword
-                    type: string
                   service:
                     default: CinderPassword
                     type: string

--- a/config/crd/bases/cinder.openstack.org_cinders.yaml
+++ b/config/crd/bases/cinder.openstack.org_cinders.yaml
@@ -338,10 +338,10 @@ spec:
                 type: object
               customServiceConfig:
                 type: string
-              databaseInstance:
-                type: string
-              databaseUser:
+              databaseAccount:
                 default: cinder
+                type: string
+              databaseInstance:
                 type: string
               dbPurge:
                 properties:
@@ -1124,12 +1124,8 @@ spec:
                 type: object
               passwordSelectors:
                 default:
-                  database: CinderDatabasePassword
                   service: CinderPassword
                 properties:
-                  database:
-                    default: CinderDatabasePassword
-                    type: string
                   service:
                     default: CinderPassword
                     type: string

--- a/config/crd/bases/cinder.openstack.org_cinderschedulers.yaml
+++ b/config/crd/bases/cinder.openstack.org_cinderschedulers.yaml
@@ -48,10 +48,10 @@ spec:
                 items:
                   type: string
                 type: array
-              databaseHostname:
-                type: string
-              databaseUser:
+              databaseAccount:
                 default: cinder
+                type: string
+              databaseHostname:
                 type: string
               extraMounts:
                 items:
@@ -819,12 +819,8 @@ spec:
                 type: object
               passwordSelectors:
                 default:
-                  database: CinderDatabasePassword
                   service: CinderPassword
                 properties:
-                  database:
-                    default: CinderDatabasePassword
-                    type: string
                   service:
                     default: CinderPassword
                     type: string

--- a/config/crd/bases/cinder.openstack.org_cindervolumes.yaml
+++ b/config/crd/bases/cinder.openstack.org_cindervolumes.yaml
@@ -48,10 +48,10 @@ spec:
                 items:
                   type: string
                 type: array
-              databaseHostname:
-                type: string
-              databaseUser:
+              databaseAccount:
                 default: cinder
+                type: string
+              databaseHostname:
                 type: string
               extraMounts:
                 items:
@@ -819,12 +819,8 @@ spec:
                 type: object
               passwordSelectors:
                 default:
-                  database: CinderDatabasePassword
                   service: CinderPassword
                 properties:
-                  database:
-                    default: CinderDatabasePassword
-                    type: string
                   service:
                     default: CinderPassword
                     type: string

--- a/config/samples/cinder_v1beta1_cinder.yaml
+++ b/config/samples/cinder_v1beta1_cinder.yaml
@@ -9,7 +9,7 @@ spec:
     [DEFAULT]
     debug = true
   databaseInstance: openstack
-  databaseUser: cinder
+  databaseAccount: cinder
   rabbitMqClusterName: rabbitmq
   cinderAPI: {}
   cinderScheduler: {}

--- a/config/samples/cinder_v1beta1_cinder_tls.yaml
+++ b/config/samples/cinder_v1beta1_cinder_tls.yaml
@@ -9,7 +9,7 @@ spec:
     [DEFAULT]
     debug = true
   databaseInstance: openstack
-  databaseUser: cinder
+  databaseAccount: cinder
   rabbitMqClusterName: rabbitmq
   cinderAPI:
     tls:

--- a/controllers/cinder_controller.go
+++ b/controllers/cinder_controller.go
@@ -349,7 +349,7 @@ func (r *CinderReconciler) reconcileDelete(ctx context.Context, instance *cinder
 	Log.Info(fmt.Sprintf("Reconciling Service '%s' delete", instance.Name))
 
 	// remove db finalizer first
-	db, err := mariadbv1.GetDatabaseByName(ctx, helper, instance.Name)
+	db, err := mariadbv1.GetDatabaseByNameAndAccount(ctx, helper, instance.Name, instance.Spec.DatabaseAccount, instance.Namespace)
 	if err != nil && !k8s_errors.IsNotFound(err) {
 		return ctrl.Result{}, err
 	}
@@ -826,6 +826,11 @@ func (r *CinderReconciler) reconcileNormal(ctx context.Context, instance *cinder
 	instance.Status.Conditions.MarkTrue(condition.CronJobReadyCondition, condition.CronJobReadyMessage)
 	// create CronJob - end
 
+	err = mariadbv1.DeleteUnusedMariaDBAccountFinalizers(ctx, helper, instance.Name, instance.Spec.DatabaseAccount, instance.Namespace)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
 	Log.Info(fmt.Sprintf("Reconciled Service '%s' successfully", instance.Name))
 	return ctrl.Result{}, nil
 }
@@ -872,15 +877,11 @@ func (r *CinderReconciler) generateServiceConfigs(
 
 	labels := labels.GetLabels(instance, labels.GetGroupLabel(cinder.ServiceName), serviceLabels)
 
-	db, err := mariadbv1.GetDatabaseByName(ctx, h, cinder.DatabaseName)
-	if err != nil {
-		return err
-	}
-
 	var tlsCfg *tls.Service
 	if instance.Spec.CinderAPI.TLS.Ca.CaBundleSecretName != "" {
 		tlsCfg = &tls.Service{}
 	}
+
 	// customData hold any customization for all cinder services.
 	customData := map[string]string{
 		cinder.CustomConfigFileName: instance.Spec.CustomServiceConfig,
@@ -910,6 +911,9 @@ func (r *CinderReconciler) generateServiceConfigs(
 		return err
 	}
 
+	databaseAccount := db.GetAccount()
+	dbSecret := db.GetSecret()
+
 	templateParameters := make(map[string]interface{})
 	templateParameters["ServiceUser"] = instance.Spec.ServiceUser
 	templateParameters["ServicePassword"] = string(ospSecret.Data[instance.Spec.PasswordSelectors.Service])
@@ -917,8 +921,8 @@ func (r *CinderReconciler) generateServiceConfigs(
 	templateParameters["KeystonePublicURL"] = keystonePublicURL
 	templateParameters["TransportURL"] = string(transportURLSecret.Data["transport_url"])
 	templateParameters["DatabaseConnection"] = fmt.Sprintf("mysql+pymysql://%s:%s@%s/%s?read_default_file=/etc/my.cnf",
-		instance.Spec.DatabaseUser,
-		string(ospSecret.Data[instance.Spec.PasswordSelectors.Database]),
+		databaseAccount.Spec.UserName,
+		string(dbSecret.Data[mariadbv1.DatabasePasswordSelector]),
 		instance.Status.DatabaseHostname,
 		cinder.DatabaseName)
 	templateParameters["MemcachedServersWithInet"] = strings.Join(memcached.Status.ServerListWithInet, ",")
@@ -1242,24 +1246,43 @@ func (r *CinderReconciler) ensureDB(
 	h *helper.Helper,
 	instance *cinderv1beta1.Cinder,
 ) (*mariadbv1.Database, ctrl.Result, error) {
-	//
-	// create service DB instance
-	//
-	db := mariadbv1.NewDatabase(
-		instance.Name,
-		instance.Spec.DatabaseUser,
-		instance.Spec.Secret,
-		map[string]string{
-			"dbName": instance.Spec.DatabaseInstance,
-		},
+	// ensure MariaDBAccount exists.  This account record may be created by
+	// openstack-operator or the cloud operator up front without a specific
+	// MariaDBDatabase configured yet.   Otherwise, a MariaDBAccount CR is
+	// created here with a generated username as well as a secret with
+	// generated password.   The MariaDBAccount is created without being
+	// yet associated with any MariaDBDatabase.
+	_, _, err := mariadbv1.EnsureMariaDBAccount(
+		ctx, h, instance.Spec.DatabaseAccount,
+		instance.Namespace, false, "cinder",
+	)
+
+	if err != nil {
+		instance.Status.Conditions.Set(condition.FalseCondition(
+			mariadbv1.MariaDBAccountReadyCondition,
+			condition.ErrorReason,
+			condition.SeverityWarning,
+			mariadbv1.MariaDBAccountNotReadyMessage,
+			err.Error()))
+
+		return nil, ctrl.Result{}, err
+	}
+	instance.Status.Conditions.MarkTrue(
+		mariadbv1.MariaDBAccountReadyCondition,
+		mariadbv1.MariaDBAccountReadyMessage,
+	)
+
+	db := mariadbv1.NewDatabaseForAccount(
+		instance.Spec.DatabaseInstance, // mariadb/galera service to target
+		instance.Name,                  // name used in CREATE DATABASE in mariadb
+		instance.Name,                  // CR name for MariaDBDatabase
+		instance.Spec.DatabaseAccount,  // CR name for MariaDBAccount
+		instance.Namespace,             // namespace
 	)
 
 	// create or patch the DB
-	ctrlResult, err := db.CreateOrPatchDBByName(
-		ctx,
-		h,
-		instance.Spec.DatabaseInstance,
-	)
+	ctrlResult, err := db.CreateOrPatchAll(ctx, h)
+
 	if err != nil {
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.DBReadyCondition,

--- a/go.mod
+++ b/go.mod
@@ -7,13 +7,13 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.4.0
 	github.com/onsi/ginkgo/v2 v2.15.0
-	github.com/onsi/gomega v1.30.0
+	github.com/onsi/gomega v1.31.1
 	github.com/openstack-k8s-operators/infra-operator/apis v0.3.1-0.20240219072823-a587b364203f
 	github.com/openstack-k8s-operators/keystone-operator/api v0.3.1-0.20240219094943-9bbb46c9afba
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240216173409-86913e6d5885
 	github.com/openstack-k8s-operators/lib-common/modules/storage v0.3.1-0.20240216173409-86913e6d5885
 	github.com/openstack-k8s-operators/lib-common/modules/test v0.3.1-0.20240216173409-86913e6d5885
-	github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240219072536-62f6b4dc7798
+	github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240303091826-438dde8600d3
 	golang.org/x/exp v0.0.0-20240213143201-ec583247a57a
 	k8s.io/api v0.28.7
 	k8s.io/apimachinery v0.28.7

--- a/go.sum
+++ b/go.sum
@@ -87,8 +87,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/onsi/ginkgo/v2 v2.15.0 h1:79HwNRBAZHOEwrczrgSOPy+eFTTlIGELKy5as+ClttY=
 github.com/onsi/ginkgo/v2 v2.15.0/go.mod h1:HlxMHtYF57y6Dpf+mc5529KKmSq9h2FpCF+/ZkwUxKM=
-github.com/onsi/gomega v1.30.0 h1:hvMK7xYz4D3HapigLTeGdId/NcfQx1VHMJc60ew99+8=
-github.com/onsi/gomega v1.30.0/go.mod h1:9sxs+SwGrKI0+PWe4Fxa9tFQQBG5xSsSbMXOI8PPpoQ=
+github.com/onsi/gomega v1.31.1 h1:KYppCUK+bUgAZwHOu7EXVBKyQA6ILvOESHkn/tgoqvo=
+github.com/onsi/gomega v1.31.1/go.mod h1:y40C95dwAD1Nz36SsEnxvfFe8FFfNxzI5eJ0EYGyAy0=
 github.com/openshift/api v0.0.0-20230414143018-3367bc7e6ac7 h1:rncLxJBpFGqBztyxCMwNRnMjhhIDOWHJowi6q8G6koI=
 github.com/openshift/api v0.0.0-20230414143018-3367bc7e6ac7/go.mod h1:ctXNyWanKEjGj8sss1KjjHQ3ENKFm33FFnS5BKaIPh4=
 github.com/openstack-k8s-operators/infra-operator/apis v0.3.1-0.20240219072823-a587b364203f h1:suf/08227pC+qQRbsUPLMOSw3mJ82b0o9Hs7MO/g9BY=
@@ -103,8 +103,8 @@ github.com/openstack-k8s-operators/lib-common/modules/storage v0.3.1-0.202402161
 github.com/openstack-k8s-operators/lib-common/modules/storage v0.3.1-0.20240216173409-86913e6d5885/go.mod h1:sK82mkh2UzITsbNa/y6AKTZftHQnsYigqRx+rFbfZM4=
 github.com/openstack-k8s-operators/lib-common/modules/test v0.3.1-0.20240216173409-86913e6d5885 h1:ioJ2MO3vAcBkLM+0UBu5IuKW/DPXcyiNSOLq0Xvn+Nw=
 github.com/openstack-k8s-operators/lib-common/modules/test v0.3.1-0.20240216173409-86913e6d5885/go.mod h1:82nzS+DbBe1tzaMvNHH8FctmZzQ14ZAJysFGsMJiivo=
-github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240219072536-62f6b4dc7798 h1:zL4DdQ5HPXCLHeRMAWC2zI7ypbkZVYg3UkyEFSnzeow=
-github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240219072536-62f6b4dc7798/go.mod h1:PDqfLbP4ZWqQHAu1OtbjfpOGQUKSzLqRJChvE/9pcyQ=
+github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240303091826-438dde8600d3 h1:fwb+GvvnN9Mhkgg5pBksZ8W5+hLCcNOorHsUTQYA1Lg=
+github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240303091826-438dde8600d3/go.mod h1:f9IIyWeoskWoeWaDFF3qmAJ2Kqyovfi0Ar/QUfk3qag=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/test/functional/cinder_test_data.go
+++ b/test/functional/cinder_test_data.go
@@ -39,7 +39,7 @@ type CinderTestData struct {
 	RabbitmqClusterName    string
 	RabbitmqSecretName     string
 	MemcachedInstance      string
-	CinderDataBaseUser     string
+	CinderDataBaseAccount  string
 	CinderPassword         string
 	CinderServiceUser      string
 	DatabaseHostname       string
@@ -150,10 +150,10 @@ func GetCinderTestData(cinderName types.NamespacedName) CinderTestData {
 			Namespace: cinderName.Namespace,
 			Name:      "internalapi",
 		},
-		RabbitmqClusterName: "rabbitmq",
-		RabbitmqSecretName:  "rabbitmq-secret",
-		MemcachedInstance:   MemcachedInstance,
-		CinderDataBaseUser:  "cinder",
+		RabbitmqClusterName:   "rabbitmq",
+		RabbitmqSecretName:    "rabbitmq-secret",
+		MemcachedInstance:     MemcachedInstance,
+		CinderDataBaseAccount: "cinder",
 		// Password used for both db and service
 		CinderPassword:    "12345678",
 		CinderServiceUser: "cinder",

--- a/test/kuttl/common/assert_sample_deployment.yaml
+++ b/test/kuttl/common/assert_sample_deployment.yaml
@@ -8,7 +8,7 @@ spec:
     [DEFAULT]
     debug = true
   databaseInstance: openstack
-  databaseUser: cinder
+  databaseAccount: cinder
   rabbitMqClusterName: rabbitmq
   cinderAPI:
     replicas: 1

--- a/test/kuttl/common/assert_tls_sample_deployment.yaml
+++ b/test/kuttl/common/assert_tls_sample_deployment.yaml
@@ -8,7 +8,7 @@ spec:
     [DEFAULT]
     debug = true
   databaseInstance: openstack
-  databaseUser: cinder
+  databaseAccount: cinder
   rabbitMqClusterName: rabbitmq
   cinderAPI:
     replicas: 1


### PR DESCRIPTION
This moves cinder to fully use MariaDBAccount based on the dev work being done for mariadb-operator:

https://github.com/openstack-k8s-operators/mariadb-operator/pull/184/files

Lead Jira: [OSPRH-4095](https://issues.redhat.com/browse/OSPRH-4095)

1. [x] controller calls EnsureMariaDBAccount up front to make sure MariaDBAccount is present
2. [x] error code from EnsureMariaDBAccount is handled, Conditions are amended when error is returned
3. [x] controller calls NewDatabaseForAccount instead of NewDatabase
4. [x]  GetAccountAndSecret is used to retrieve account /secret to populate template
5. [x]  GetDatabaseByName() , normally used for delete finalizers, replaced with GetDatabaseByNameAndAccount
6. [x]  CreateOrPatchAll() used to patch the Database, replacing CreateOrPatchDB / CreateOrPatchDBByName
7. [x]  controller calls DeleteUnusedMariaDBAccountFinalizers when launched pods are definitely running on a new MariaDBAccount, returns error code if present
8. [x]  PasswordSelectors that refer to database are removed
9. [x]  all databaseUser replaced with databaseAccount inside of all XYZ_types.go
10. [x] all databaseUser replaced with databaseAccount inside of all `kuttl/*.yaml`
11. [x] all default databaseUser names become databaseAccount, replacing underscores with dashes inside of all XYZ_types.go
12. [x] all default databaseUser names become databaseAccount, replacing underscores with dashes inside of all `kuttl/*.yaml`
13. [x] MariaDBAccountSuiteTests are used in controller ginkgo tests if it has them
14. [x] [184](https://github.com/openstack-k8s-operators/mariadb-operator/pull/184) is merged and replaces from go.mod are removed 

