### PR TITLE
Remove notifications TODO

### DIFF
--- a/templates/cinder/config/00-global-defaults.conf
+++ b/templates/cinder/config/00-global-defaults.conf
@@ -45,10 +45,11 @@ lock_path = /var/locks/openstack/os-brick
 [oslo_concurrency]
 lock_path = /var/locks/openstack/cinder
 
-# TODO:
-#[oslo_messaging_notifications]
-#transport_url = rabbit://stackrabbit:secret@192.168.122.19:5672/
-#driver = messagingv2
+# Notifications are disabled by default, can be enabled by setting the driver
+# to messagingv2 at the top level cinder customServiceConfig
+[oslo_messaging_notifications]
+transport_url = {{ .TransportURL }}
+driver = noop
 
 [oslo_messaging_rabbit]
 heartbeat_timeout_threshold=60


### PR DESCRIPTION
This patch updates our global default configuration that had a TODO for the cinder notifications to explicitly state that it is disabled by default and that it's very easy to enable it.

This is an excerpt of what a human operator would need to add to enable it:

```
apiVersion: core.openstack.org/v1beta1
kind: OpenStackControlPlane
spec:
  cinder:
    customServiceConfig: |
      [oslo_messaging_notifications]
      driver = messagingv2
      transport_url = {{ .TransportURL }}
```

Jira: #[OSPRH-1613](https://issues.redhat.com//browse/OSPRH-1613)