### PR TITLE
Restart services when their NodeSelector changes

### DIFF
--- a/controllers/cinderapi_controller.go
+++ b/controllers/cinderapi_controller.go
@@ -707,6 +707,20 @@ func (r *CinderAPIReconciler) reconcileNormal(ctx context.Context, instance *cin
 	instance.Status.Conditions.MarkTrue(condition.TLSInputReadyCondition, condition.InputReadyMessage)
 
 	//
+	// Hash the nodeSelector so the pod is recreated when it changes
+	//
+	err = cinder.AddNodeSelectorHash(instance.Spec.NodeSelector, &configVars)
+	if err != nil {
+		instance.Status.Conditions.Set(condition.FalseCondition(
+			condition.ServiceConfigReadyCondition,
+			condition.ErrorReason,
+			condition.SeverityWarning,
+			condition.ServiceConfigReadyErrorMessage,
+			err.Error()))
+		return ctrl.Result{}, err
+	}
+
+	//
 	// Create secrets required as input for the Service and calculate an overall hash of hashes
 	//
 	serviceLabels := map[string]string{

--- a/controllers/cinderscheduler_controller.go
+++ b/controllers/cinderscheduler_controller.go
@@ -410,6 +410,20 @@ func (r *CinderSchedulerReconciler) reconcileNormal(ctx context.Context, instanc
 	instance.Status.Conditions.MarkTrue(condition.TLSInputReadyCondition, condition.InputReadyMessage)
 
 	//
+	// Hash the nodeSelector so the pod is recreated when it changes
+	//
+	err = cinder.AddNodeSelectorHash(instance.Spec.NodeSelector, &configVars)
+	if err != nil {
+		instance.Status.Conditions.Set(condition.FalseCondition(
+			condition.ServiceConfigReadyCondition,
+			condition.ErrorReason,
+			condition.SeverityWarning,
+			condition.ServiceConfigReadyErrorMessage,
+			err.Error()))
+		return ctrl.Result{}, err
+	}
+
+	//
 	// Create ConfigMaps required as input for the Service and calculate an overall hash of hashes
 	//
 	serviceLabels := map[string]string{

--- a/controllers/cindervolume_controller.go
+++ b/controllers/cindervolume_controller.go
@@ -435,6 +435,20 @@ func (r *CinderVolumeReconciler) reconcileNormal(ctx context.Context, instance *
 	}
 
 	//
+	// Hash the nodeSelector so the pod is recreated when it changes
+	//
+	err = cinder.AddNodeSelectorHash(instance.Spec.NodeSelector, &configVars)
+	if err != nil {
+		instance.Status.Conditions.Set(condition.FalseCondition(
+			condition.ServiceConfigReadyCondition,
+			condition.ErrorReason,
+			condition.SeverityWarning,
+			condition.ServiceConfigReadyErrorMessage,
+			err.Error()))
+		return ctrl.Result{}, err
+	}
+
+	//
 	// create hash over all the different input resources to identify if any those changed
 	// and a restart/recreate is required.
 	//

--- a/pkg/cinder/funcs.go
+++ b/pkg/cinder/funcs.go
@@ -3,6 +3,8 @@ package cinder
 import (
 	common "github.com/openstack-k8s-operators/lib-common/modules/common"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/affinity"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/env"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
 
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -46,4 +48,13 @@ func GetPodAffinity(componentName string) *corev1.Affinity {
 		},
 		corev1.LabelHostname,
 	)
+}
+
+// AddNodeSelectorHash - Adds a hash of a nodeSelector map to the envVars.
+func AddNodeSelectorHash(nodeSelector map[string]string, envVars *map[string]env.Setter) error {
+	hash, err := util.ObjectHash(nodeSelector)
+	if err != nil {
+		(*envVars)["NodeSelectorHash"] = env.SetValue(hash)
+	}
+	return err
 }


### PR DESCRIPTION
Add a hash of a service's Spec.NodeSelector to the inputs that determine when the corresponding pod should be recreated. This ensures pods are restarted whenever the NodeSelector is modified.