### PR TITLE
Use PodManagementPolicy: appsv1.ParallelPodManagement for cinder api statefulset

### DIFF
--- a/pkg/cinderapi/statefuleset.go
+++ b/pkg/cinderapi/statefuleset.go
@@ -116,7 +116,8 @@ func StatefulSet(
 			Selector: &metav1.LabelSelector{
 				MatchLabels: labels,
 			},
-			Replicas: instance.Spec.Replicas,
+			PodManagementPolicy: appsv1.ParallelPodManagement,
+			Replicas:            instance.Spec.Replicas,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: annotations,

--- a/test/kuttl/common/assert_sample_deployment.yaml
+++ b/test/kuttl/common/assert_sample_deployment.yaml
@@ -31,7 +31,7 @@ metadata:
     kind: CinderAPI
     name: cinder-api
 spec:
-  podManagementPolicy: OrderedReady
+  podManagementPolicy: Parallel
   replicas: 1
   revisionHistoryLimit: 10
   selector:


### PR DESCRIPTION
With the default PodManagementPolicy: OrderedReadyPodManagement the statefulset controller will only progress pods when the previous/current pod is ready or terminated.

When service configuration changes while the pod is starting and the new configuration requires e.g. additional volume mounts the initial pod will never reach ready and therefore an update won't happen.

With ParallelPodManagement the statefulset controller will not wait for pods to be ready or complete termination.