### PR TITLE
Revert "Restart services when their NodeSelector changes"

### DIFF
--- a/controllers/cinderapi_controller.go
+++ b/controllers/cinderapi_controller.go
@@ -707,20 +707,6 @@ func (r *CinderAPIReconciler) reconcileNormal(ctx context.Context, instance *cin
 	instance.Status.Conditions.MarkTrue(condition.TLSInputReadyCondition, condition.InputReadyMessage)
 
 	//
-	// Hash the nodeSelector so the pod is recreated when it changes
-	//
-	err = cinder.AddNodeSelectorHash(instance.Spec.NodeSelector, &configVars)
-	if err != nil {
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			condition.ServiceConfigReadyCondition,
-			condition.ErrorReason,
-			condition.SeverityWarning,
-			condition.ServiceConfigReadyErrorMessage,
-			err.Error()))
-		return ctrl.Result{}, err
-	}
-
-	//
 	// Create secrets required as input for the Service and calculate an overall hash of hashes
 	//
 	serviceLabels := map[string]string{

--- a/controllers/cinderbackup_controller.go
+++ b/controllers/cinderbackup_controller.go
@@ -411,20 +411,6 @@ func (r *CinderBackupReconciler) reconcileNormal(ctx context.Context, instance *
 	instance.Status.Conditions.MarkTrue(condition.TLSInputReadyCondition, condition.InputReadyMessage)
 
 	//
-	// Hash the nodeSelector so the pod is recreated when it changes
-	//
-	err = cinder.AddNodeSelectorHash(instance.Spec.NodeSelector, &configVars)
-	if err != nil {
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			condition.ServiceConfigReadyCondition,
-			condition.ErrorReason,
-			condition.SeverityWarning,
-			condition.ServiceConfigReadyErrorMessage,
-			err.Error()))
-		return ctrl.Result{}, err
-	}
-
-	//
 	// Create secrets required as input for the Service and calculate an overall hash of hashes
 	//
 	serviceLabels := map[string]string{

--- a/controllers/cinderscheduler_controller.go
+++ b/controllers/cinderscheduler_controller.go
@@ -410,20 +410,6 @@ func (r *CinderSchedulerReconciler) reconcileNormal(ctx context.Context, instanc
 	instance.Status.Conditions.MarkTrue(condition.TLSInputReadyCondition, condition.InputReadyMessage)
 
 	//
-	// Hash the nodeSelector so the pod is recreated when it changes
-	//
-	err = cinder.AddNodeSelectorHash(instance.Spec.NodeSelector, &configVars)
-	if err != nil {
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			condition.ServiceConfigReadyCondition,
-			condition.ErrorReason,
-			condition.SeverityWarning,
-			condition.ServiceConfigReadyErrorMessage,
-			err.Error()))
-		return ctrl.Result{}, err
-	}
-
-	//
 	// Create ConfigMaps required as input for the Service and calculate an overall hash of hashes
 	//
 	serviceLabels := map[string]string{

--- a/controllers/cindervolume_controller.go
+++ b/controllers/cindervolume_controller.go
@@ -435,20 +435,6 @@ func (r *CinderVolumeReconciler) reconcileNormal(ctx context.Context, instance *
 	}
 
 	//
-	// Hash the nodeSelector so the pod is recreated when it changes
-	//
-	err = cinder.AddNodeSelectorHash(instance.Spec.NodeSelector, &configVars)
-	if err != nil {
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			condition.ServiceConfigReadyCondition,
-			condition.ErrorReason,
-			condition.SeverityWarning,
-			condition.ServiceConfigReadyErrorMessage,
-			err.Error()))
-		return ctrl.Result{}, err
-	}
-
-	//
 	// create hash over all the different input resources to identify if any those changed
 	// and a restart/recreate is required.
 	//

--- a/pkg/cinder/funcs.go
+++ b/pkg/cinder/funcs.go
@@ -3,8 +3,6 @@ package cinder
 import (
 	common "github.com/openstack-k8s-operators/lib-common/modules/common"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/affinity"
-	"github.com/openstack-k8s-operators/lib-common/modules/common/env"
-	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
 
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -48,13 +46,4 @@ func GetPodAffinity(componentName string) *corev1.Affinity {
 		},
 		corev1.LabelHostname,
 	)
-}
-
-// AddNodeSelectorHash - Adds a hash of a nodeSelector map to the envVars.
-func AddNodeSelectorHash(nodeSelector map[string]string, envVars *map[string]env.Setter) error {
-	hash, err := util.ObjectHash(nodeSelector)
-	if err != nil {
-		(*envVars)["NodeSelectorHash"] = env.SetValue(hash)
-	}
-	return err
 }


### PR DESCRIPTION
This reverts commit df33f3ef495813f393a1cc9fc18555118463b9a1.

PR #353 was thought to be the solution to a problem observed while testing updates to how we manage cinder's LVM backend. This pertained to the use of a nodeSelector label that pins the c-vol pod to the k8s node where the LVM backend data is stored. Unfortunately, two subsequent issues were uncovered.

First, the nodeSelector already affects a service's statefulset, which in turn causes pods to be restarted automatically, There's no need to add the nodeSelector to the collection of hashes we use to restart pods when their configuration changes.

Second, the actual problem scenario we hoped to solve was getting a pod to be recreated when it got stuck in the Pending state due to a bad nodeSelector value. Currently we use an "Ordered" pod management policy, which means a Pending pod will need to be manually deleted. Hashing the nodeSelector has no impact on pods stuck in the Pending state.