### PR TITLE
Update some backend samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,8 @@ cli.
           - CinderBackup
           volumes:
           - name: ceph
-            projected:
-              sources:
-              - secret:
-                  name: ceph-client-conf
+            secret:
+              secretName: ceph-client-conf
           mounts:
           - name: ceph
             mountPath: "/etc/ceph"
@@ -151,10 +149,8 @@ spec:
         extraVolType: Ceph
         volumes:
         - name: ceph
-          projected:
-            sources:
-            - secret:
-                name: ceph-client-files
+          secret:
+            secretName: ceph-client-conf
         mounts:
         - name: ceph
           mountPath: "/etc/ceph"

--- a/config/samples/backends/ceph/backend.yaml
+++ b/config/samples/backends/ceph/backend.yaml
@@ -17,10 +17,8 @@ spec:
           extraVolType: Ceph
           volumes:
           - name: ceph
-            projected:
-              sources:
-              - secret:
-                  name: ceph-conf-files
+            secret:
+              secretName: ceph-conf-files
           mounts:
           - name: ceph
             mountPath: "/etc/ceph"

--- a/config/samples/backends/netapp/ontap/nfs/backend.yaml
+++ b/config/samples/backends/netapp/ontap/nfs/backend.yaml
@@ -1,50 +1,32 @@
 # To be able to use this sample it is necessary to:
 # - Have a NetApp ONTAP backend with NFS support
-# - Have the NetApp storage credentials and NFS configuration in cinder-volume-netapp-secrets.yaml
+# - Have the NetApp storage credentials and NFS configuration in cinder-volume-ontap-secrets.yaml
+#
+# NOTE: Rather than using a shares-config file, the driver uses the nas_host
+# and nas_share_path parameters in the secrets file. For multiple shares,
+# configure a separate cinder-volume backend and secrets file for each share.
 
 apiVersion: core.openstack.org/v1beta1
 kind: OpenStackControlPlane
 metadata:
   name: openstack
 spec:
-  # We need to "drop" the "nfs_shares_config" file into the volume service.
-  # The contents come from a secret that we are creating in the
-  # "cinder-volume-ontap-secrets.yaml" file. This drops the secret in
-  # /etc/cinder/nfs_shares.d directory, and then the key in the secret defines
-  # the name of the file, in our case shares-config. That's why the
-  # configuration option defines that the location is
-  # /etc/cinder/nfs_shares.d/shares-config.
-  extraMounts:
-    - name: v1
-      region: r1
-      extraVol:
-        - propagation:
-          - CinderVolume
-          extraVolType: Undefined
-          volumes:
-          - name: nfs-shares
-            projected:
-              sources:
-              - secret:
-                  name: cinder-volume-ontap-shares-secrets
-          mounts:
-          - name: nfs-shares
-            mountPath: /etc/cinder/nfs_shares.d
-            readOnly: true
   cinder:
     template:
       cinderVolumes:
-        ontap-iscsi:
+        ontap-nfs:
           networkAttachments:
           - storage
-          customServiceConfigSecrets:
-            - cinder-volume-ontap-secrets
           customServiceConfig: |
             [ontap]
             volume_backend_name=ontap
             volume_driver=cinder.volume.drivers.netapp.common.NetAppDriver
+            nfs_snapshot_support=true
+            nas_secure_file_operations=false
+            nas_secure_file_permissions=false
             netapp_server_hostname=hostname
             netapp_server_port=80
             netapp_storage_protocol=nfs
             netapp_storage_family=ontap_cluster
-            nfs_shares_config=/etc/cinder/nfs_shares.d/shares-config
+          customServiceConfigSecrets:
+          - cinder-volume-ontap-secrets

--- a/config/samples/backends/netapp/ontap/nfs/cinder-volume-ontap-secrets.yaml
+++ b/config/samples/backends/netapp/ontap/nfs/cinder-volume-ontap-secrets.yaml
@@ -1,5 +1,5 @@
 # Define the "cinder-volume-ontap-secrets" Secret that contains sensitive
-# information pertaining to the [iscsi] backend.
+# information pertaining to the [ontap] backend.
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,21 +9,10 @@ metadata:
   name: cinder-volume-ontap-secrets
 type: Opaque
 stringData:
-  ontap-cinder-secrets.conf: |
+  ontap-cinder-secrets: |
     [ontap]
     netapp_login=admin_username
     netapp_password=admin_password
     netapp_vserver=svm_name
----
-apiVersion: v1
-kind: Secret
-metadata:
-  labels:
-    service: cinder
-    component: cinder-volume
-  name: cinder-volume-ontap-shares-secrets
-type: Opaque
-stringData:
-  shares-config: |
-    10.63.165.215:/nfs/test
-    10.63.165.215:/nfs2/test2
+    nas_host=10.63.165.215
+    nas_share_path=/nfs/test

--- a/config/samples/backends/nfs/backend.yaml
+++ b/config/samples/backends/nfs/backend.yaml
@@ -1,5 +1,10 @@
 # Deploy a cinder NFS backend, with sensitive server settings (the nas_host
 # and nas_share_path) stored in the "cinder-volume-nfs-secrets" Secret.
+#
+# NOTE: Rather than using a shares-config file, the driver uses the nas_host
+# and nas_share_path parameters in the secrets file. For multiple shares,
+# configure a separate cinder-volume backend and secrets file for each share.
+
 apiVersion: core.openstack.org/v1beta1
 kind: OpenStackControlPlane
 metadata:

--- a/config/samples/backends/nfs/cinder-volume-nfs-secrets.yaml
+++ b/config/samples/backends/nfs/cinder-volume-nfs-secrets.yaml
@@ -9,7 +9,7 @@ metadata:
   name: cinder-volume-nfs-secrets
 type: Opaque
 stringData:
-  nfs-secrets.conf: |
+  cinder-volume-nfs-secrets: |
     [nfs]
     nas_host=192.168.130.1
     nas_share_path=/var/nfs/cinder


### PR DESCRIPTION
Update extraMounts for mounting ceph client files to use the 'secret' volume type instead of 'projected'. The projected volume type is meant for situations where there are multiple sources that need to all be merged, but with ceph there's just a single source.

Update the NFS and Netapp's ontap NFS configurations to switch from using a shares-config file to using the driver's nas_host and nas_share_patch config options. The shares-config file is not considered best practice for situations where multiple shares need to be configured. Instead, it's better to configure multiple backends, one per share, so that all volume requests go through the scheduler.

The NFS configurations also now include a few more recommended settings:

  nfs_snapshot_support=true
  nas_secure_file_operations=false
  nas_secure_file_permissions=false