### PR TITLE
Ensure golangci-lint runs on all files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ repos:
 - repo: https://github.com/golangci/golangci-lint
   rev: v1.55.2
   hooks:
-    - id: golangci-lint
+    - id: golangci-lint-full
       args: ["-v"]
 
 - repo: local

--- a/controllers/cinder_controller.go
+++ b/controllers/cinder_controller.go
@@ -244,7 +244,7 @@ var (
 )
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *CinderReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
+func (r *CinderReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// transportURLSecretFn - Watch for changes made to the secret associated with the RabbitMQ
 	// TransportURL created and used by Cinder CRs.  Watch functions return a list of namespace-scoped
 	// CRs that then get fed  to the reconciler.  Hence, in this case, we need to know the name of the
@@ -302,7 +302,7 @@ func (r *CinderReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manage
 		listOpts := []client.ListOption{
 			client.InNamespace(o.GetNamespace()),
 		}
-		if err := r.Client.List(context.Background(), cinders, listOpts...); err != nil {
+		if err := r.Client.List(ctx, cinders, listOpts...); err != nil {
 			Log.Error(err, "Unable to retrieve Cinder CRs %w")
 			return nil
 		}
@@ -652,7 +652,7 @@ func (r *CinderReconciler) reconcileNormal(ctx context.Context, instance *cinder
 	}
 
 	// Handle service update
-	ctrlResult, err = r.reconcileUpdate(ctx, instance, helper)
+	ctrlResult, err = r.reconcileUpdate(ctx, instance)
 	if err != nil {
 		return ctrlResult, err
 	} else if (ctrlResult != ctrl.Result{}) {
@@ -660,7 +660,7 @@ func (r *CinderReconciler) reconcileNormal(ctx context.Context, instance *cinder
 	}
 
 	// Handle service upgrade
-	ctrlResult, err = r.reconcileUpgrade(ctx, instance, helper)
+	ctrlResult, err = r.reconcileUpgrade(ctx, instance)
 	if err != nil {
 		return ctrlResult, err
 	} else if (ctrlResult != ctrl.Result{}) {
@@ -849,7 +849,7 @@ func (r *CinderReconciler) reconcileNormal(ctx context.Context, instance *cinder
 	return ctrl.Result{}, nil
 }
 
-func (r *CinderReconciler) reconcileUpdate(ctx context.Context, instance *cinderv1beta1.Cinder, helper *helper.Helper) (ctrl.Result, error) {
+func (r *CinderReconciler) reconcileUpdate(ctx context.Context, instance *cinderv1beta1.Cinder) (ctrl.Result, error) {
 	Log := r.GetLogger(ctx)
 
 	Log.Info(fmt.Sprintf("Reconciling Service '%s' update", instance.Name))
@@ -861,7 +861,7 @@ func (r *CinderReconciler) reconcileUpdate(ctx context.Context, instance *cinder
 	return ctrl.Result{}, nil
 }
 
-func (r *CinderReconciler) reconcileUpgrade(ctx context.Context, instance *cinderv1beta1.Cinder, helper *helper.Helper) (ctrl.Result, error) {
+func (r *CinderReconciler) reconcileUpgrade(ctx context.Context, instance *cinderv1beta1.Cinder) (ctrl.Result, error) {
 	Log := r.GetLogger(ctx)
 
 	Log.Info(fmt.Sprintf("Reconciling Service '%s' upgrade", instance.Name))

--- a/main.go
+++ b/main.go
@@ -127,7 +127,7 @@ func main() {
 		Client:  mgr.GetClient(),
 		Scheme:  mgr.GetScheme(),
 		Kclient: kclient,
-	}).SetupWithManager(context.Background(), mgr); err != nil {
+	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Cinder")
 		os.Exit(1)
 	}

--- a/pkg/cindervolume/volumes.go
+++ b/pkg/cindervolume/volumes.go
@@ -32,11 +32,11 @@ func GetVolumes(parentName string, name string, extraVol []cinderv1beta1.CinderE
 
 // GetVolumeMounts - Cinder Volume VolumeMounts
 func GetVolumeMounts(name string, extraVol []cinderv1beta1.CinderExtraVolMounts, usesLVM bool) []corev1.VolumeMount {
-	var config_data string
+	var configData string
 	if usesLVM {
-		config_data = "cinder-volume-lvm-config.json"
+		configData = "cinder-volume-lvm-config.json"
 	} else {
-		config_data = "cinder-volume-config.json"
+		configData = "cinder-volume-config.json"
 	}
 	volumeVolumeMounts := []corev1.VolumeMount{
 		{
@@ -47,7 +47,7 @@ func GetVolumeMounts(name string, extraVol []cinderv1beta1.CinderExtraVolMounts,
 		{
 			Name:      "config-data",
 			MountPath: "/var/lib/kolla/config_files/config.json",
-			SubPath:   config_data,
+			SubPath:   configData,
 			ReadOnly:  true,
 		},
 	}

--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -18,7 +18,7 @@ import (
 
 	"golang.org/x/exp/maps"
 
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega" //revive:disable:dot-imports
 	corev1 "k8s.io/api/core/v1"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"

--- a/test/functional/cinder_controller_test.go
+++ b/test/functional/cinder_controller_test.go
@@ -18,9 +18,12 @@ package functional
 import (
 	"fmt"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo/v2" //revive:disable:dot-imports
+	. "github.com/onsi/gomega"    //revive:disable:dot-imports
+
+	//revive:disable-next-line:dot-imports
 	. "github.com/openstack-k8s-operators/lib-common/modules/common/test/helpers"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"

--- a/test/functional/suite_test.go
+++ b/test/functional/suite_test.go
@@ -26,8 +26,8 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo/v2" //revive:disable:dot-imports
+	. "github.com/onsi/gomega"    //revive:disable:dot-imports
 
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
@@ -198,7 +198,7 @@ var _ = BeforeSuite(func() {
 		Client:  k8sManager.GetClient(),
 		Scheme:  k8sManager.GetScheme(),
 		Kclient: kclient,
-	}).SetupWithManager(context.Background(), k8sManager)
+	}).SetupWithManager(k8sManager)
 
 	Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
* removed unused func params
* ignore revive dot-imports rule on ginkgo and gomega as dot import
there is the recommended practice
* various small style fixes found by the linter
