### PR TITLE
Fixing conditions

### DIFF
--- a/api/bases/cinder.openstack.org_cinderapis.yaml
+++ b/api/bases/cinder.openstack.org_cinderapis.yaml
@@ -986,6 +986,9 @@ spec:
                     type: string
                   type: array
                 type: object
+              observedGeneration:
+                format: int64
+                type: integer
               readyCount:
                 default: 0
                 format: int32

--- a/api/bases/cinder.openstack.org_cinderapis.yaml
+++ b/api/bases/cinder.openstack.org_cinderapis.yaml
@@ -987,12 +987,16 @@ spec:
                   type: array
                 type: object
               readyCount:
+                default: 0
                 format: int32
+                minimum: 0
                 type: integer
               serviceIDs:
                 additionalProperties:
                   type: string
                 type: object
+            required:
+            - readyCount
             type: object
         type: object
     served: true

--- a/api/bases/cinder.openstack.org_cinderbackups.yaml
+++ b/api/bases/cinder.openstack.org_cinderbackups.yaml
@@ -917,8 +917,12 @@ spec:
                   type: array
                 type: object
               readyCount:
+                default: 0
                 format: int32
+                minimum: 0
                 type: integer
+            required:
+            - readyCount
             type: object
         type: object
     served: true

--- a/api/bases/cinder.openstack.org_cinderbackups.yaml
+++ b/api/bases/cinder.openstack.org_cinderbackups.yaml
@@ -916,6 +916,9 @@ spec:
                     type: string
                   type: array
                 type: object
+              observedGeneration:
+                format: int64
+                type: integer
               readyCount:
                 default: 0
                 format: int32

--- a/api/bases/cinder.openstack.org_cinders.yaml
+++ b/api/bases/cinder.openstack.org_cinders.yaml
@@ -1152,13 +1152,19 @@ spec:
                   type: object
                 type: object
               cinderAPIReadyCount:
+                default: 0
                 format: int32
+                minimum: 0
                 type: integer
               cinderBackupReadyCount:
+                default: 0
                 format: int32
+                minimum: 0
                 type: integer
               cinderSchedulerReadyCount:
+                default: 0
                 format: int32
+                minimum: 0
                 type: integer
               cinderVolumesReadyCounts:
                 additionalProperties:
@@ -1202,6 +1208,10 @@ spec:
                 type: object
               transportURLSecret:
                 type: string
+            required:
+            - cinderAPIReadyCount
+            - cinderBackupReadyCount
+            - cinderSchedulerReadyCount
             type: object
         type: object
     served: true

--- a/api/bases/cinder.openstack.org_cinderschedulers.yaml
+++ b/api/bases/cinder.openstack.org_cinderschedulers.yaml
@@ -917,8 +917,12 @@ spec:
                   type: array
                 type: object
               readyCount:
+                default: 0
                 format: int32
+                minimum: 0
                 type: integer
+            required:
+            - readyCount
             type: object
         type: object
     served: true

--- a/api/bases/cinder.openstack.org_cinderschedulers.yaml
+++ b/api/bases/cinder.openstack.org_cinderschedulers.yaml
@@ -916,6 +916,9 @@ spec:
                     type: string
                   type: array
                 type: object
+              observedGeneration:
+                format: int64
+                type: integer
               readyCount:
                 default: 0
                 format: int32

--- a/api/bases/cinder.openstack.org_cindervolumes.yaml
+++ b/api/bases/cinder.openstack.org_cindervolumes.yaml
@@ -917,6 +917,9 @@ spec:
                     type: string
                   type: array
                 type: object
+              observedGeneration:
+                format: int64
+                type: integer
               readyCount:
                 default: 0
                 format: int32

--- a/api/bases/cinder.openstack.org_cindervolumes.yaml
+++ b/api/bases/cinder.openstack.org_cindervolumes.yaml
@@ -918,8 +918,12 @@ spec:
                   type: array
                 type: object
               readyCount:
+                default: 0
                 format: int32
+                minimum: 0
                 type: integer
+            required:
+            - readyCount
             type: object
         type: object
     served: true

--- a/api/v1beta1/cinder_types.go
+++ b/api/v1beta1/cinder_types.go
@@ -177,7 +177,10 @@ type CinderStatus struct {
 	// ReadyCounts of Cinder Volume instances
 	CinderVolumesReadyCounts map[string]int32 `json:"cinderVolumesReadyCounts,omitempty"`
 
-	//ObservedGeneration - the most recent generation observed for this service. If the observed generation is less than the spec generation, then the controller has not processed the latest changes.
+	// ObservedGeneration - the most recent generation observed for this service.
+	// If the observed generation is different than the spec generation, then thei
+	// controller has not started processing the latest changes, and the status
+	// and its conditions are likely stale.
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 

--- a/api/v1beta1/cinder_types.go
+++ b/api/v1beta1/cinder_types.go
@@ -226,7 +226,8 @@ func init() {
 
 // IsReady - returns true if all subresources Ready condition is true
 func (instance Cinder) IsReady() bool {
-	return instance.Status.Conditions.IsTrue(CinderAPIReadyCondition) &&
+	return instance.Generation == instance.Status.ObservedGeneration &&
+		instance.Status.Conditions.IsTrue(CinderAPIReadyCondition) &&
 		instance.Status.Conditions.IsTrue(CinderBackupReadyCondition) &&
 		instance.Status.Conditions.IsTrue(CinderSchedulerReadyCondition) &&
 		instance.Status.Conditions.IsTrue(CinderVolumeReadyCondition)

--- a/api/v1beta1/cinder_types.go
+++ b/api/v1beta1/cinder_types.go
@@ -178,7 +178,7 @@ type CinderStatus struct {
 	CinderVolumesReadyCounts map[string]int32 `json:"cinderVolumesReadyCounts,omitempty"`
 
 	// ObservedGeneration - the most recent generation observed for this service.
-	// If the observed generation is different than the spec generation, then thei
+	// If the observed generation is different than the spec generation, then the
 	// controller has not started processing the latest changes, and the status
 	// and its conditions are likely stale.
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`

--- a/api/v1beta1/cinder_types.go
+++ b/api/v1beta1/cinder_types.go
@@ -160,13 +160,19 @@ type CinderStatus struct {
 	ServiceIDs map[string]string `json:"serviceIDs,omitempty"`
 
 	// ReadyCount of Cinder API instance
-	CinderAPIReadyCount int32 `json:"cinderAPIReadyCount,omitempty"`
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:default=0
+	CinderAPIReadyCount int32 `json:"cinderAPIReadyCount"`
 
 	// ReadyCount of Cinder Backup instance
-	CinderBackupReadyCount int32 `json:"cinderBackupReadyCount,omitempty"`
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:default=0
+	CinderBackupReadyCount int32 `json:"cinderBackupReadyCount"`
 
 	// ReadyCount of Cinder Scheduler instance
-	CinderSchedulerReadyCount int32 `json:"cinderSchedulerReadyCount,omitempty"`
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:default=0
+	CinderSchedulerReadyCount int32 `json:"cinderSchedulerReadyCount"`
 
 	// ReadyCounts of Cinder Volume instances
 	CinderVolumesReadyCounts map[string]int32 `json:"cinderVolumesReadyCounts,omitempty"`

--- a/api/v1beta1/cinderapi_types.go
+++ b/api/v1beta1/cinderapi_types.go
@@ -106,6 +106,12 @@ type CinderAPIStatus struct {
 
 	// NetworkAttachments status of the deployment pods
 	NetworkAttachments map[string][]string `json:"networkAttachments,omitempty"`
+
+	// ObservedGeneration - the most recent generation observed for this service.
+	// If the observed generation is different than the spec generation, then the
+	// controller has not started processing the latest changes, and the status
+	// and its conditions are likely stale.
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/api/v1beta1/cinderapi_types.go
+++ b/api/v1beta1/cinderapi_types.go
@@ -144,5 +144,8 @@ func init() {
 
 // IsReady - returns true if service is ready to serve requests
 func (instance CinderAPI) IsReady() bool {
-	return instance.Status.ReadyCount == *instance.Spec.Replicas
+	return instance.Generation == instance.Status.ObservedGeneration &&
+		instance.Status.ReadyCount == *instance.Spec.Replicas &&
+		(instance.Status.Conditions.IsTrue(condition.DeploymentReadyCondition) ||
+			(instance.Status.Conditions.IsFalse(condition.DeploymentReadyCondition) && *instance.Spec.Replicas == 0))
 }

--- a/api/v1beta1/cinderapi_types.go
+++ b/api/v1beta1/cinderapi_types.go
@@ -97,7 +97,9 @@ type CinderAPIStatus struct {
 	Conditions condition.Conditions `json:"conditions,omitempty" optional:"true"`
 
 	// ReadyCount of Cinder API instances
-	ReadyCount int32 `json:"readyCount,omitempty"`
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:default=0
+	ReadyCount int32 `json:"readyCount"`
 
 	// ServiceIDs
 	ServiceIDs map[string]string `json:"serviceIDs,omitempty"`

--- a/api/v1beta1/cinderbackup_types.go
+++ b/api/v1beta1/cinderbackup_types.go
@@ -82,7 +82,9 @@ type CinderBackupStatus struct {
 	Conditions condition.Conditions `json:"conditions,omitempty" optional:"true"`
 
 	// ReadyCount of Cinder Backup instances
-	ReadyCount int32 `json:"readyCount,omitempty"`
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:default=0
+	ReadyCount int32 `json:"readyCount"`
 
 	// NetworkAttachments status of the deployment pods
 	NetworkAttachments map[string][]string `json:"networkAttachments,omitempty"`

--- a/api/v1beta1/cinderbackup_types.go
+++ b/api/v1beta1/cinderbackup_types.go
@@ -126,5 +126,8 @@ func init() {
 
 // IsReady - returns true if service is ready to serve requests
 func (instance CinderBackup) IsReady() bool {
-	return instance.Status.ReadyCount == *instance.Spec.Replicas
+	return instance.Generation == instance.Status.ObservedGeneration &&
+		instance.Status.ReadyCount == *instance.Spec.Replicas &&
+		(instance.Status.Conditions.IsTrue(condition.DeploymentReadyCondition) ||
+			(instance.Status.Conditions.IsFalse(condition.DeploymentReadyCondition) && *instance.Spec.Replicas == 0))
 }

--- a/api/v1beta1/cinderbackup_types.go
+++ b/api/v1beta1/cinderbackup_types.go
@@ -88,6 +88,12 @@ type CinderBackupStatus struct {
 
 	// NetworkAttachments status of the deployment pods
 	NetworkAttachments map[string][]string `json:"networkAttachments,omitempty"`
+
+	// ObservedGeneration - the most recent generation observed for this service.
+	// If the observed generation is different than the spec generation, then the
+	// controller has not started processing the latest changes, and the status
+	// and its conditions are likely stale.
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/api/v1beta1/cinderscheduler_types.go
+++ b/api/v1beta1/cinderscheduler_types.go
@@ -126,5 +126,8 @@ func init() {
 
 // IsReady - returns true if service is ready to serve requests
 func (instance CinderScheduler) IsReady() bool {
-	return instance.Status.ReadyCount == *instance.Spec.Replicas
+	return instance.Generation == instance.Status.ObservedGeneration &&
+		instance.Status.ReadyCount == *instance.Spec.Replicas &&
+		(instance.Status.Conditions.IsTrue(condition.DeploymentReadyCondition) ||
+			(instance.Status.Conditions.IsFalse(condition.DeploymentReadyCondition) && *instance.Spec.Replicas == 0))
 }

--- a/api/v1beta1/cinderscheduler_types.go
+++ b/api/v1beta1/cinderscheduler_types.go
@@ -82,7 +82,9 @@ type CinderSchedulerStatus struct {
 	Conditions condition.Conditions `json:"conditions,omitempty" optional:"true"`
 
 	// ReadyCount of Cinder Scheduler instances
-	ReadyCount int32 `json:"readyCount,omitempty"`
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:default=0
+	ReadyCount int32 `json:"readyCount"`
 
 	// NetworkAttachments status of the deployment pods
 	NetworkAttachments map[string][]string `json:"networkAttachments,omitempty"`

--- a/api/v1beta1/cinderscheduler_types.go
+++ b/api/v1beta1/cinderscheduler_types.go
@@ -88,6 +88,12 @@ type CinderSchedulerStatus struct {
 
 	// NetworkAttachments status of the deployment pods
 	NetworkAttachments map[string][]string `json:"networkAttachments,omitempty"`
+
+	// ObservedGeneration - the most recent generation observed for this service.
+	// If the observed generation is different than the spec generation, then the
+	// controller has not started processing the latest changes, and the status
+	// and its conditions are likely stale.
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/api/v1beta1/cindervolume_types.go
+++ b/api/v1beta1/cindervolume_types.go
@@ -83,7 +83,9 @@ type CinderVolumeStatus struct {
 	Conditions condition.Conditions `json:"conditions,omitempty" optional:"true"`
 
 	// ReadyCount of Cinder Volume instances
-	ReadyCount int32 `json:"readyCount,omitempty"`
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:default=0
+	ReadyCount int32 `json:"readyCount"`
 
 	// NetworkAttachments status of the deployment pods
 	NetworkAttachments map[string][]string `json:"networkAttachments,omitempty"`

--- a/api/v1beta1/cindervolume_types.go
+++ b/api/v1beta1/cindervolume_types.go
@@ -127,5 +127,8 @@ func init() {
 
 // IsReady - returns true if service is ready to serve requests
 func (instance CinderVolume) IsReady() bool {
-	return instance.Status.ReadyCount == *instance.Spec.Replicas
+	return instance.Generation == instance.Status.ObservedGeneration &&
+		instance.Status.ReadyCount == *instance.Spec.Replicas &&
+		(instance.Status.Conditions.IsTrue(condition.DeploymentReadyCondition) ||
+			(instance.Status.Conditions.IsFalse(condition.DeploymentReadyCondition) && *instance.Spec.Replicas == 0))
 }

--- a/api/v1beta1/cindervolume_types.go
+++ b/api/v1beta1/cindervolume_types.go
@@ -89,6 +89,12 @@ type CinderVolumeStatus struct {
 
 	// NetworkAttachments status of the deployment pods
 	NetworkAttachments map[string][]string `json:"networkAttachments,omitempty"`
+
+	// ObservedGeneration - the most recent generation observed for this service.
+	// If the observed generation is different than the spec generation, then the
+	// controller has not started processing the latest changes, and the status
+	// and its conditions are likely stale.
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/config/crd/bases/cinder.openstack.org_cinderapis.yaml
+++ b/config/crd/bases/cinder.openstack.org_cinderapis.yaml
@@ -986,6 +986,9 @@ spec:
                     type: string
                   type: array
                 type: object
+              observedGeneration:
+                format: int64
+                type: integer
               readyCount:
                 default: 0
                 format: int32

--- a/config/crd/bases/cinder.openstack.org_cinderapis.yaml
+++ b/config/crd/bases/cinder.openstack.org_cinderapis.yaml
@@ -987,12 +987,16 @@ spec:
                   type: array
                 type: object
               readyCount:
+                default: 0
                 format: int32
+                minimum: 0
                 type: integer
               serviceIDs:
                 additionalProperties:
                   type: string
                 type: object
+            required:
+            - readyCount
             type: object
         type: object
     served: true

--- a/config/crd/bases/cinder.openstack.org_cinderbackups.yaml
+++ b/config/crd/bases/cinder.openstack.org_cinderbackups.yaml
@@ -917,8 +917,12 @@ spec:
                   type: array
                 type: object
               readyCount:
+                default: 0
                 format: int32
+                minimum: 0
                 type: integer
+            required:
+            - readyCount
             type: object
         type: object
     served: true

--- a/config/crd/bases/cinder.openstack.org_cinderbackups.yaml
+++ b/config/crd/bases/cinder.openstack.org_cinderbackups.yaml
@@ -916,6 +916,9 @@ spec:
                     type: string
                   type: array
                 type: object
+              observedGeneration:
+                format: int64
+                type: integer
               readyCount:
                 default: 0
                 format: int32

--- a/config/crd/bases/cinder.openstack.org_cinders.yaml
+++ b/config/crd/bases/cinder.openstack.org_cinders.yaml
@@ -1152,13 +1152,19 @@ spec:
                   type: object
                 type: object
               cinderAPIReadyCount:
+                default: 0
                 format: int32
+                minimum: 0
                 type: integer
               cinderBackupReadyCount:
+                default: 0
                 format: int32
+                minimum: 0
                 type: integer
               cinderSchedulerReadyCount:
+                default: 0
                 format: int32
+                minimum: 0
                 type: integer
               cinderVolumesReadyCounts:
                 additionalProperties:
@@ -1202,6 +1208,10 @@ spec:
                 type: object
               transportURLSecret:
                 type: string
+            required:
+            - cinderAPIReadyCount
+            - cinderBackupReadyCount
+            - cinderSchedulerReadyCount
             type: object
         type: object
     served: true

--- a/config/crd/bases/cinder.openstack.org_cinderschedulers.yaml
+++ b/config/crd/bases/cinder.openstack.org_cinderschedulers.yaml
@@ -917,8 +917,12 @@ spec:
                   type: array
                 type: object
               readyCount:
+                default: 0
                 format: int32
+                minimum: 0
                 type: integer
+            required:
+            - readyCount
             type: object
         type: object
     served: true

--- a/config/crd/bases/cinder.openstack.org_cinderschedulers.yaml
+++ b/config/crd/bases/cinder.openstack.org_cinderschedulers.yaml
@@ -916,6 +916,9 @@ spec:
                     type: string
                   type: array
                 type: object
+              observedGeneration:
+                format: int64
+                type: integer
               readyCount:
                 default: 0
                 format: int32

--- a/config/crd/bases/cinder.openstack.org_cindervolumes.yaml
+++ b/config/crd/bases/cinder.openstack.org_cindervolumes.yaml
@@ -917,6 +917,9 @@ spec:
                     type: string
                   type: array
                 type: object
+              observedGeneration:
+                format: int64
+                type: integer
               readyCount:
                 default: 0
                 format: int32

--- a/config/crd/bases/cinder.openstack.org_cindervolumes.yaml
+++ b/config/crd/bases/cinder.openstack.org_cindervolumes.yaml
@@ -918,8 +918,12 @@ spec:
                   type: array
                 type: object
               readyCount:
+                default: 0
                 format: int32
+                minimum: 0
                 type: integer
+            required:
+            - readyCount
             type: object
         type: object
     served: true

--- a/controllers/cinder_controller.go
+++ b/controllers/cinder_controller.go
@@ -196,6 +196,8 @@ func (r *CinderReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 		condition.UnknownCondition(condition.RoleBindingReadyCondition, condition.InitReason, condition.RoleBindingReadyInitMessage),
 	)
 	instance.Status.Conditions.Init(&cl)
+	// Always mark the Generation as observed early on
+	instance.Status.ObservedGeneration = instance.Generation
 
 	// If we're not deleting this and the service object doesn't have our finalizer, add it.
 	if (instance.DeletionTimestamp.IsZero() && controllerutil.AddFinalizer(instance, helper.GetFinalizer())) || isNewInstance {
@@ -841,7 +843,6 @@ func (r *CinderReconciler) reconcileNormal(ctx context.Context, instance *cinder
 	}
 
 	Log.Info(fmt.Sprintf("Reconciled Service '%s' successfully", instance.Name))
-	instance.Status.ObservedGeneration = instance.Generation
 	// update the overall status condition if service is ready
 	if instance.IsReady() {
 		instance.Status.Conditions.MarkTrue(condition.ReadyCondition, condition.ReadyMessage)

--- a/controllers/cinderapi_controller.go
+++ b/controllers/cinderapi_controller.go
@@ -173,6 +173,8 @@ func (r *CinderAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		condition.UnknownCondition(condition.TLSInputReadyCondition, condition.InitReason, condition.InputReadyInitMessage),
 	)
 	instance.Status.Conditions.Init(&cl)
+	// Always mark the Generation as observed early on
+	instance.Status.ObservedGeneration = instance.Generation
 
 	// If we're not deleting this and the service object doesn't have our finalizer, add it.
 	if (instance.DeletionTimestamp.IsZero() && controllerutil.AddFinalizer(instance, helper.GetFinalizer())) || isNewInstance {

--- a/controllers/cinderapi_controller.go
+++ b/controllers/cinderapi_controller.go
@@ -873,6 +873,7 @@ func (r *CinderAPIReconciler) reconcileNormal(ctx context.Context, instance *cin
 		time.Duration(5)*time.Second,
 	)
 
+	var ssData appsv1.StatefulSet
 	ctrlResult, err = ss.CreateOrPatch(ctx, helper)
 	if err != nil {
 		instance.Status.Conditions.Set(condition.FalseCondition(
@@ -882,15 +883,32 @@ func (r *CinderAPIReconciler) reconcileNormal(ctx context.Context, instance *cin
 			condition.DeploymentReadyErrorMessage,
 			err.Error()))
 		return ctrlResult, err
-	} else if (ctrlResult != ctrl.Result{}) {
+
+	} else if (ctrlResult == ctrl.Result{}) {
+		// Wait until the data in the StatefulSet is for the current generation
+		ssData = ss.GetStatefulSet()
+		if ssData.Generation != ssData.Status.ObservedGeneration {
+			ctrlResult = ctrl.Result{RequeueAfter: time.Duration(10) * time.Second}
+			err = fmt.Errorf("waiting for Statefulset %s to start reconciling", ssData.Name)
+		}
+	}
+
+	if (ctrlResult != ctrl.Result{}) {
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.DeploymentReadyCondition,
 			condition.RequestedReason,
 			condition.SeverityInfo,
 			condition.DeploymentReadyRunningMessage))
-		return ctrlResult, nil
+		// If the deployment is not ready, then neither are the NADs
+		instance.Status.Conditions.Set(condition.FalseCondition(
+			condition.NetworkAttachmentsReadyCondition,
+			condition.RequestedReason,
+			condition.SeverityInfo,
+			condition.NetworkAttachmentsReadyInitMessage))
+		return ctrlResult, err
 	}
-	instance.Status.ReadyCount = ss.GetStatefulSet().Status.ReadyReplicas
+
+	instance.Status.ReadyCount = ssData.Status.ReadyReplicas
 
 	// verify if network attachment matches expectations
 	networkReady := false
@@ -956,6 +974,7 @@ func (r *CinderAPIReconciler) reconcileNormal(ctx context.Context, instance *cin
 	if instance.IsReady() {
 		instance.Status.Conditions.MarkTrue(condition.ReadyCondition, condition.ReadyMessage)
 	}
+	// For non ready we'll let the main defer func handle the status update using the Mirror function
 	return ctrl.Result{}, nil
 }
 

--- a/controllers/cinderbackup_controller.go
+++ b/controllers/cinderbackup_controller.go
@@ -153,6 +153,8 @@ func (r *CinderBackupReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		condition.UnknownCondition(condition.TLSInputReadyCondition, condition.InitReason, condition.InputReadyInitMessage),
 	)
 	instance.Status.Conditions.Init(&cl)
+	// Always mark the Generation as observed early on
+	instance.Status.ObservedGeneration = instance.Generation
 
 	// If we're not deleting this and the service object doesn't have our finalizer, add it.
 	if (instance.DeletionTimestamp.IsZero() && controllerutil.AddFinalizer(instance, helper.GetFinalizer())) || isNewInstance {

--- a/controllers/cinderbackup_controller.go
+++ b/controllers/cinderbackup_controller.go
@@ -543,6 +543,7 @@ func (r *CinderBackupReconciler) reconcileNormal(ctx context.Context, instance *
 		time.Duration(5)*time.Second,
 	)
 
+	var ssData appsv1.StatefulSet
 	ctrlResult, err = ss.CreateOrPatch(ctx, helper)
 	if err != nil {
 		instance.Status.Conditions.Set(condition.FalseCondition(
@@ -552,15 +553,32 @@ func (r *CinderBackupReconciler) reconcileNormal(ctx context.Context, instance *
 			condition.DeploymentReadyErrorMessage,
 			err.Error()))
 		return ctrlResult, err
-	} else if (ctrlResult != ctrl.Result{}) {
+
+	} else if (ctrlResult == ctrl.Result{}) {
+		// Wait until the data in the StatefulSet is for the current generation
+		ssData = ss.GetStatefulSet()
+		if ssData.Generation != ssData.Status.ObservedGeneration {
+			ctrlResult = ctrl.Result{RequeueAfter: time.Duration(10) * time.Second}
+			err = fmt.Errorf("waiting for Statefulset %s to start reconciling", ssData.Name)
+		}
+	}
+
+	if (ctrlResult != ctrl.Result{}) {
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.DeploymentReadyCondition,
 			condition.RequestedReason,
 			condition.SeverityInfo,
 			condition.DeploymentReadyRunningMessage))
-		return ctrlResult, nil
+		// If the deployment is not ready, then neither are the NADs
+		instance.Status.Conditions.Set(condition.FalseCondition(
+			condition.NetworkAttachmentsReadyCondition,
+			condition.RequestedReason,
+			condition.SeverityInfo,
+			condition.NetworkAttachmentsReadyInitMessage))
+		return ctrlResult, err
 	}
-	instance.Status.ReadyCount = ss.GetStatefulSet().Status.ReadyReplicas
+
+	instance.Status.ReadyCount = ssData.Status.ReadyReplicas
 
 	// verify if network attachment matches expectations
 	networkReady := false
@@ -625,6 +643,7 @@ func (r *CinderBackupReconciler) reconcileNormal(ctx context.Context, instance *
 	if instance.IsReady() {
 		instance.Status.Conditions.MarkTrue(condition.ReadyCondition, condition.ReadyMessage)
 	}
+	// For non ready we'll let the main defer func handle the status update using the Mirror function
 	return ctrl.Result{}, nil
 }
 

--- a/controllers/cinderscheduler_controller.go
+++ b/controllers/cinderscheduler_controller.go
@@ -542,6 +542,7 @@ func (r *CinderSchedulerReconciler) reconcileNormal(ctx context.Context, instanc
 		time.Duration(5)*time.Second,
 	)
 
+	var ssData appsv1.StatefulSet
 	ctrlResult, err = ss.CreateOrPatch(ctx, helper)
 	if err != nil {
 		instance.Status.Conditions.Set(condition.FalseCondition(
@@ -551,15 +552,32 @@ func (r *CinderSchedulerReconciler) reconcileNormal(ctx context.Context, instanc
 			condition.DeploymentReadyErrorMessage,
 			err.Error()))
 		return ctrlResult, err
-	} else if (ctrlResult != ctrl.Result{}) {
+
+	} else if (ctrlResult == ctrl.Result{}) {
+		// Wait until the data in the StatefulSet is for the current generation
+		ssData = ss.GetStatefulSet()
+		if ssData.Generation != ssData.Status.ObservedGeneration {
+			ctrlResult = ctrl.Result{RequeueAfter: time.Duration(10) * time.Second}
+			err = fmt.Errorf("waiting for Statefulset %s to start reconciling", ssData.Name)
+		}
+	}
+
+	if (ctrlResult != ctrl.Result{}) {
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.DeploymentReadyCondition,
 			condition.RequestedReason,
 			condition.SeverityInfo,
 			condition.DeploymentReadyRunningMessage))
-		return ctrlResult, nil
+		// If the deployment is not ready, then neither are the NADs
+		instance.Status.Conditions.Set(condition.FalseCondition(
+			condition.NetworkAttachmentsReadyCondition,
+			condition.RequestedReason,
+			condition.SeverityInfo,
+			condition.NetworkAttachmentsReadyInitMessage))
+		return ctrlResult, err
 	}
-	instance.Status.ReadyCount = ss.GetStatefulSet().Status.ReadyReplicas
+
+	instance.Status.ReadyCount = ssData.Status.ReadyReplicas
 
 	// verify if network attachment matches expectations
 	networkReady := false
@@ -624,6 +642,7 @@ func (r *CinderSchedulerReconciler) reconcileNormal(ctx context.Context, instanc
 	if instance.IsReady() {
 		instance.Status.Conditions.MarkTrue(condition.ReadyCondition, condition.ReadyMessage)
 	}
+	// For non ready we'll let the main defer func handle the status update using the Mirror function
 	return ctrl.Result{}, nil
 }
 

--- a/controllers/cinderscheduler_controller.go
+++ b/controllers/cinderscheduler_controller.go
@@ -153,6 +153,8 @@ func (r *CinderSchedulerReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		condition.UnknownCondition(condition.TLSInputReadyCondition, condition.InitReason, condition.InputReadyInitMessage),
 	)
 	instance.Status.Conditions.Init(&cl)
+	// Always mark the Generation as observed early on
+	instance.Status.ObservedGeneration = instance.Generation
 
 	// If we're not deleting this and the service object doesn't have our finalizer, add it.
 	if (instance.DeletionTimestamp.IsZero() && controllerutil.AddFinalizer(instance, helper.GetFinalizer())) || isNewInstance {

--- a/controllers/cindervolume_controller.go
+++ b/controllers/cindervolume_controller.go
@@ -155,6 +155,8 @@ func (r *CinderVolumeReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		condition.UnknownCondition(condition.TLSInputReadyCondition, condition.InitReason, condition.InputReadyInitMessage),
 	)
 	instance.Status.Conditions.Init(&cl)
+	// Always mark the Generation as observed early on
+	instance.Status.ObservedGeneration = instance.Generation
 
 	// If we're not deleting this and the service object doesn't have our finalizer, add it.
 	if (instance.DeletionTimestamp.IsZero() && controllerutil.AddFinalizer(instance, helper.GetFinalizer())) || isNewInstance {

--- a/controllers/cindervolume_controller.go
+++ b/controllers/cindervolume_controller.go
@@ -545,6 +545,7 @@ func (r *CinderVolumeReconciler) reconcileNormal(ctx context.Context, instance *
 		time.Duration(5)*time.Second,
 	)
 
+	var ssData appsv1.StatefulSet
 	ctrlResult, err = ss.CreateOrPatch(ctx, helper)
 	if err != nil {
 		instance.Status.Conditions.Set(condition.FalseCondition(
@@ -554,15 +555,32 @@ func (r *CinderVolumeReconciler) reconcileNormal(ctx context.Context, instance *
 			condition.DeploymentReadyErrorMessage,
 			err.Error()))
 		return ctrlResult, err
-	} else if (ctrlResult != ctrl.Result{}) {
+
+	} else if (ctrlResult == ctrl.Result{}) {
+		// Wait until the data in the StatefulSet is for the current generation
+		ssData = ss.GetStatefulSet()
+		if ssData.Generation != ssData.Status.ObservedGeneration {
+			ctrlResult = ctrl.Result{RequeueAfter: time.Duration(10) * time.Second}
+			err = fmt.Errorf("waiting for Statefulset %s to start reconciling", ssData.Name)
+		}
+	}
+
+	if (ctrlResult != ctrl.Result{}) {
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.DeploymentReadyCondition,
 			condition.RequestedReason,
 			condition.SeverityInfo,
 			condition.DeploymentReadyRunningMessage))
-		return ctrlResult, nil
+		// If the deployment is not ready, then neither are the NADs
+		instance.Status.Conditions.Set(condition.FalseCondition(
+			condition.NetworkAttachmentsReadyCondition,
+			condition.RequestedReason,
+			condition.SeverityInfo,
+			condition.NetworkAttachmentsReadyInitMessage))
+		return ctrlResult, err
 	}
-	instance.Status.ReadyCount = ss.GetStatefulSet().Status.ReadyReplicas
+
+	instance.Status.ReadyCount = ssData.Status.ReadyReplicas
 
 	// verify if network attachment matches expectations
 	networkReady := false
@@ -627,6 +645,7 @@ func (r *CinderVolumeReconciler) reconcileNormal(ctx context.Context, instance *
 	if instance.IsReady() {
 		instance.Status.Conditions.MarkTrue(condition.ReadyCondition, condition.ReadyMessage)
 	}
+	// For non ready we'll let the main defer func handle the status update using the Mirror function
 	return ctrl.Result{}, nil
 }
 


### PR DESCRIPTION
In this PR we fix the cinder operator to follow the latest recommendations on how to handle the status conditions of the CRDs.

At a high level the changes are:

- All CRDs have an `ObservedGeneration` field
- `ObservedGeneration` is updated with the `Generation` field value set by OpenShift as soon as the status conditions are initialized to `Unknown` in the beginning of the reconciliation.
- Top level `Cinder` CRD only considers sub CRDs to have valid data when their `Generation` and `ObservedGeneration` fields match.
- All controllers take into account their `ObservedGeneration` field to determine whether they are ready or not.