### PR TITLE
Wait for DB writes only on reads (causality checks)

### DIFF
--- a/templates/cinder/config/00-global-defaults.conf
+++ b/templates/cinder/config/00-global-defaults.conf
@@ -39,10 +39,11 @@ connection = {{ .DatabaseConnection }}
 max_retries = -1
 db_max_retries = -1
 
-# Wait for writes to complete when doing a read, update, or insert
-# Relevant for multi-master deployments so that workers table works as intended
+# Wait for writes to complete when doing reads
+# Relevant for multi-master deployments so that workers table, and possibly
+# other tables, work as intended
 # https://mariadb.com/docs/server/ref/mdb/system-variables/wsrep_sync_wait/
-mysql_wsrep_sync_wait = 7
+mysql_wsrep_sync_wait = 1
 
 [os_brick]
 lock_path = /var/locks/openstack/os-brick


### PR DESCRIPTION
On PR 392 we changed to waiting on writes for updates and inserts, but upon further analysis we have decided that just doing it for reads should be enough, as the order of the updates will be reconciled automatically by the DB engine.

In this patch we change the value of `mysql_wsrep_sync_wait` to 1 to only wait on reads.