### PR TITLE
Do not configure cinder's default_availability_zone

### DIFF
--- a/templates/cinder/config/00-global-defaults.conf
+++ b/templates/cinder/config/00-global-defaults.conf
@@ -8,7 +8,6 @@ auth_strategy = keystone
 glance_catalog_info = image:glance:internalURL
 allowed_direct_url_schemes = cinder
 storage_availability_zone = nova
-default_availability_zone = nova
 # TODO: should we create our own default type?
 #default_volume_type = openstack-k8s
 scheduler_driver = cinder.scheduler.filter_scheduler.FilterScheduler


### PR DESCRIPTION
Configure cinder's storage_availability_zone but leave the default_availability_zone unset so that the user can override the default "nova" value using either parameter.

For background, cinder has separate default_availability_zone and storage_availability_zone parameters, and the former supersedes the latter. If the default_availability_zone is unset, cinder will fallback to the storage_availability_zone. So, if the cinder operator configures the default_availability_zone then a cloud admin would be unable to override it with the
storage_availability_zone parameter. Historically, tripleo only configured the storage_availability_zone.