### PR TITLE
Samples: iscsid login timeout

### DIFF
--- a/config/samples/backends/bases/iscsid/iscsid.yaml
+++ b/config/samples/backends/bases/iscsid/iscsid.yaml
@@ -9,6 +9,22 @@ spec:
   config:
     ignition:
       version: 3.2.0
+    storage:
+      files:
+        - path: /etc/iscsi/iscsid.conf
+          overwrite: true
+          # Mode must be decimal, this is 0600
+          mode: 384
+          user:
+            name: root
+          group:
+            name: root
+          contents:
+            # Source can be a http, https, tftp, s3, gs, or data as defined in rfc2397.
+            # This is the rfc2397 text/plain string format
+            # Change login timeout and retries so total time is not 120 seconds but 15 (3 x 5)
+            # This is convenient for testing with failed paths, production env may choose to leave defaults
+            source: data:,node.session.initial_login_retry_max%20%3D%203%0Anode.conn%5B0%5D.timeo.login_timeout%20%3D%205%0A
     systemd:
       units:
       - enabled: true


### PR DESCRIPTION
This patch changes the time to fail an iSCSI login request in our samples.

The default is 8 retries and 15 seconds for each one, so 120 seconds in total.

This patch changes the OpenShift cluster default to 3 retries and 5 seconds each (15 seconds in total), which is convenient for testing, as any healthy deployment and backend should be able to login to the backend in that amount of time, and if there is a broken path it will not take 2 minutes to give up.

Jira: https://issues.redhat.com/browse/OSPRH-7393
Jira: https://issues.redhat.com/browse/OSPRH-7415