### PR TITLE
Set APITimeout defaults on the webhook

### DIFF
--- a/api/v1beta1/cinder_types.go
+++ b/api/v1beta1/cinder_types.go
@@ -50,6 +50,8 @@ const (
 	DBPurgeDefaultAge = 30
 	// DBPurgeDefaultSchedule - Default cron schedule for purging the DB
 	DBPurgeDefaultSchedule = "1 0 * * *"
+	// APITimeoutDefault  - Default timeout in seconds for HAProxy, Apache, and RPCs
+	APITimeoutDefault  = 60
 )
 
 type CinderSpecBase struct {

--- a/api/v1beta1/cinder_webhook.go
+++ b/api/v1beta1/cinder_webhook.go
@@ -44,6 +44,7 @@ type CinderDefaults struct {
 	VolumeContainerImageURL    string
 	DBPurgeAge                 int
 	DBPurgeSchedule            string
+	APITimeout                 int
 }
 
 var cinderDefaults CinderDefaults
@@ -60,6 +61,7 @@ func SetupDefaults() {
 		VolumeContainerImageURL:    util.GetEnvVar("RELATED_IMAGE_CINDER_VOLUME_IMAGE_URL_DEFAULT", CinderVolumeContainerImage),
 		DBPurgeAge:                 DBPurgeDefaultAge,
 		DBPurgeSchedule:            DBPurgeDefaultSchedule,
+		APITimeout:                 APITimeoutDefault,
 	}
 
 	cinderlog.Info("Cinder defaults initialized", "defaults", cinderDefaults)
@@ -110,6 +112,9 @@ func (spec *CinderSpecBase) Default() {
 	}
 	if spec.DBPurge.Schedule == "" {
 		spec.DBPurge.Schedule = cinderDefaults.DBPurgeSchedule
+	}
+	if spec.APITimeout == 0 {
+		spec.APITimeout = cinderDefaults.APITimeout
 	}
 }
 


### PR DESCRIPTION
Kubebuilder doesn't always set the default of APITimeout, so with this patch we ensure that APITimeout field always has a valid value.