### PR TITLE
Always name database "cinder"

### DIFF
--- a/controllers/cinder_controller.go
+++ b/controllers/cinder_controller.go
@@ -354,7 +354,7 @@ func (r *CinderReconciler) reconcileDelete(ctx context.Context, instance *cinder
 	Log.Info(fmt.Sprintf("Reconciling Service '%s' delete", instance.Name))
 
 	// remove db finalizer first
-	db, err := mariadbv1.GetDatabaseByNameAndAccount(ctx, helper, instance.Name, instance.Spec.DatabaseAccount, instance.Namespace)
+	db, err := mariadbv1.GetDatabaseByNameAndAccount(ctx, helper, cinder.DatabaseName, instance.Spec.DatabaseAccount, instance.Namespace)
 	if err != nil && !k8s_errors.IsNotFound(err) {
 		return ctrl.Result{}, err
 	}
@@ -1283,8 +1283,8 @@ func (r *CinderReconciler) ensureDB(
 
 	db := mariadbv1.NewDatabaseForAccount(
 		instance.Spec.DatabaseInstance, // mariadb/galera service to target
-		instance.Name,                  // name used in CREATE DATABASE in mariadb
-		instance.Name,                  // CR name for MariaDBDatabase
+		cinder.DatabaseName,            // name used in CREATE DATABASE in mariadb
+		cinder.DatabaseName,            // CR name for MariaDBDatabase
 		instance.Spec.DatabaseAccount,  // CR name for MariaDBAccount
 		instance.Namespace,             // namespace
 	)


### PR DESCRIPTION
Current code names the database for cinder based on the Cinder CR name, and this is ok if the instance is called cinder, but if the name is something like "mycloud-cinder" then the database creation doesn't work as it fails with:
```
  ERROR 1064 (42000) at line 1: You have an error in your SQL syntax;
  check the manual that corresponds to your MariaDB server version for
  the right syntax to use near '-cinder' at line 1
```
We have a constant called `DatabaseName` that contains the name that we should be using for the database creation, and this patch uses it.

Jira: [OSPRH-7396](https://issues.redhat.com//browse/OSPRH-7396)