### PR TITLE
Fix backend label when using non cinder name

### DIFF
--- a/api/v1beta1/cindervolume_types.go
+++ b/api/v1beta1/cindervolume_types.go
@@ -22,6 +22,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	// Backend -
+	Backend = "backend"
+)
+
 // CinderVolumeTemplate defines the input parameters for the Cinder Volume service
 type CinderVolumeTemplateCore struct {
 	// Common input parameters for the Cinder Volume service
@@ -131,4 +136,9 @@ func (instance CinderVolume) IsReady() bool {
 		instance.Status.ReadyCount == *instance.Spec.Replicas &&
 		(instance.Status.Conditions.IsTrue(condition.DeploymentReadyCondition) ||
 			(instance.Status.Conditions.IsFalse(condition.DeploymentReadyCondition) && *instance.Spec.Replicas == 0))
+}
+
+// BackendName - returns the backend name of a CinderVolume instance based on the labels
+func (instance CinderVolume) BackendName() string {
+	return instance.Labels[Backend]
 }

--- a/controllers/cinder_controller.go
+++ b/controllers/cinder_controller.go
@@ -1187,6 +1187,7 @@ func (r *CinderReconciler) volumeDeploymentCreateOrUpdate(ctx context.Context, i
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-volume-%s", instance.Name, name),
 			Namespace: instance.Namespace,
+			Labels:    map[string]string{cinderv1beta1.Backend: name},
 		},
 	}
 
@@ -1226,18 +1227,14 @@ func (r *CinderReconciler) volumeCleanupDeployments(ctx context.Context, instanc
 		return nil
 	}
 
-	prefixLen := len(instance.Name + "-volume-")
 	for _, volume := range volumes.Items {
 		// Skip volumes that we don't own
 		if cinder.GetOwningCinderName(&volume) != instance.Name {
 			continue
 		}
 
-		// specName is the volume's name as it would appear in the CinderVolumes spec
-		specName := volume.Name[prefixLen:]
-
 		// Delete the volume if it's no longer in the spec
-		_, exists := instance.Spec.CinderVolumes[specName]
+		_, exists := instance.Spec.CinderVolumes[volume.BackendName()]
 		if !exists && volume.DeletionTimestamp.IsZero() {
 			err := r.Client.Delete(ctx, &volume)
 			if err != nil && !k8s_errors.IsNotFound(err) {

--- a/controllers/cinder_controller.go
+++ b/controllers/cinder_controller.go
@@ -850,7 +850,7 @@ func (r *CinderReconciler) reconcileNormal(ctx context.Context, instance *cinder
 	instance.Status.Conditions.MarkTrue(condition.CronJobReadyCondition, condition.CronJobReadyMessage)
 	// create CronJob - end
 
-	err = mariadbv1.DeleteUnusedMariaDBAccountFinalizers(ctx, helper, instance.Name, instance.Spec.DatabaseAccount, instance.Namespace)
+	err = mariadbv1.DeleteUnusedMariaDBAccountFinalizers(ctx, helper, cinder.DatabaseName, instance.Spec.DatabaseAccount, instance.Namespace)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/controllers/cindervolume_controller.go
+++ b/controllers/cindervolume_controller.go
@@ -428,7 +428,7 @@ func (r *CinderVolumeReconciler) reconcileNormal(ctx context.Context, instance *
 	serviceLabels := map[string]string{
 		common.AppSelector:       cinder.ServiceName,
 		common.ComponentSelector: cindervolume.ComponentName,
-		cindervolume.Backend:     instance.Name[len(cindervolume.ComponentName)+1:],
+		cinderv1beta1.Backend:    instance.BackendName(),
 	}
 
 	//

--- a/pkg/cindervolume/const.go
+++ b/pkg/cindervolume/const.go
@@ -18,6 +18,4 @@ package cindervolume
 const (
 	// ComponentName -
 	ComponentName = "cinder-volume"
-	// Backend -
-	Backend = "backend"
 )

--- a/test/functional/cinder_controller_test.go
+++ b/test/functional/cinder_controller_test.go
@@ -169,8 +169,8 @@ var _ = Describe("Cinder controller", func() {
 			DeferCleanup(keystone.DeleteKeystoneAPI, keystone.CreateKeystoneAPI(namespace))
 		})
 		It("Should set DBReady Condition and set DatabaseHostname Status when DB is Created", func() {
-			mariadb.SimulateMariaDBAccountCompleted(cinderTest.Instance)
-			mariadb.SimulateMariaDBDatabaseCompleted(cinderTest.Instance)
+			mariadb.SimulateMariaDBAccountCompleted(cinderTest.Database)
+			mariadb.SimulateMariaDBDatabaseCompleted(cinderTest.Database)
 			th.SimulateJobSuccess(cinderTest.CinderDBSync)
 			Cinder := GetCinder(cinderTest.Instance)
 			Expect(Cinder.Status.DatabaseHostname).To(Equal(fmt.Sprintf("hostname-for-openstack.%s.svc", namespace)))
@@ -188,8 +188,8 @@ var _ = Describe("Cinder controller", func() {
 			)
 		})
 		It("Should fail if db-sync job fails when DB is Created", func() {
-			mariadb.SimulateMariaDBAccountCompleted(cinderTest.Instance)
-			mariadb.SimulateMariaDBDatabaseCompleted(cinderTest.Instance)
+			mariadb.SimulateMariaDBAccountCompleted(cinderTest.Database)
+			mariadb.SimulateMariaDBDatabaseCompleted(cinderTest.Database)
 			th.SimulateJobFailure(cinderTest.CinderDBSync)
 			th.ExpectCondition(
 				cinderTest.Instance,
@@ -229,8 +229,8 @@ var _ = Describe("Cinder controller", func() {
 			infra.SimulateTransportURLReady(cinderTest.CinderTransportURL)
 			DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(namespace, "memcached", memcachedSpec))
 			infra.SimulateMemcachedReady(cinderTest.CinderMemcached)
-			mariadb.SimulateMariaDBAccountCompleted(cinderTest.Instance)
-			mariadb.SimulateMariaDBDatabaseCompleted(cinderTest.Instance)
+			mariadb.SimulateMariaDBAccountCompleted(cinderTest.Database)
+			mariadb.SimulateMariaDBDatabaseCompleted(cinderTest.Database)
 		})
 		It("should create config-data and scripts ConfigMaps", func() {
 			keystoneAPI := keystone.CreateKeystoneAPI(cinderTest.Instance.Namespace)
@@ -281,8 +281,8 @@ var _ = Describe("Cinder controller", func() {
 			DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(namespace, cinderTest.MemcachedInstance, memcachedSpec))
 			infra.SimulateMemcachedReady(cinderTest.CinderMemcached)
 			DeferCleanup(keystone.DeleteKeystoneAPI, keystone.CreateKeystoneAPI(cinderTest.Instance.Namespace))
-			mariadb.SimulateMariaDBAccountCompleted(cinderTest.Instance)
-			mariadb.SimulateMariaDBDatabaseCompleted(cinderTest.Instance)
+			mariadb.SimulateMariaDBAccountCompleted(cinderTest.Database)
+			mariadb.SimulateMariaDBDatabaseCompleted(cinderTest.Database)
 			th.SimulateJobSuccess(cinderTest.CinderDBSync)
 			keystone.SimulateKeystoneServiceReady(cinderTest.CinderKeystoneService)
 			keystone.SimulateKeystoneEndpointReady(cinderTest.CinderKeystoneEndpoint)
@@ -319,19 +319,19 @@ var _ = Describe("Cinder controller", func() {
 			DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(namespace, cinderTest.MemcachedInstance, memcachedSpec))
 			infra.SimulateMemcachedReady(cinderTest.CinderMemcached)
 			DeferCleanup(keystone.DeleteKeystoneAPI, keystone.CreateKeystoneAPI(cinderTest.Instance.Namespace))
-			mariadb.SimulateMariaDBAccountCompleted(cinderTest.Instance)
-			mariadb.SimulateMariaDBDatabaseCompleted(cinderTest.Instance)
+			mariadb.SimulateMariaDBAccountCompleted(cinderTest.Database)
+			mariadb.SimulateMariaDBDatabaseCompleted(cinderTest.Database)
 			th.SimulateJobSuccess(cinderTest.CinderDBSync)
 		})
 		It("removes the finalizers from the Cinder DB", func() {
 			keystone.SimulateKeystoneServiceReady(cinderTest.CinderKeystoneService)
 
-			mDB := mariadb.GetMariaDBDatabase(cinderTest.Instance)
+			mDB := mariadb.GetMariaDBDatabase(cinderTest.Database)
 			Expect(mDB.Finalizers).To(ContainElement("openstack.org/cinder"))
 
 			th.DeleteInstance(GetCinder(cinderTest.Instance))
 
-			mDB = mariadb.GetMariaDBDatabase(cinderTest.Instance)
+			mDB = mariadb.GetMariaDBDatabase(cinderTest.Database)
 			Expect(mDB.Finalizers).NotTo(ContainElement("openstack.org/cinder"))
 		})
 	})
@@ -401,8 +401,8 @@ var _ = Describe("Cinder controller", func() {
 			Eventually(func(g Gomega) {
 				g.Expect(k8sClient.Status().Update(ctx, keystoneAPI.DeepCopy())).Should(Succeed())
 			}, timeout, interval).Should(Succeed())
-			mariadb.SimulateMariaDBAccountCompleted(cinderTest.Instance)
-			mariadb.SimulateMariaDBDatabaseCompleted(cinderTest.Instance)
+			mariadb.SimulateMariaDBAccountCompleted(cinderTest.Database)
+			mariadb.SimulateMariaDBDatabaseCompleted(cinderTest.Database)
 			th.SimulateJobSuccess(cinderTest.CinderDBSync)
 			keystone.SimulateKeystoneServiceReady(cinderTest.CinderKeystoneService)
 		})
@@ -475,8 +475,8 @@ var _ = Describe("Cinder controller", func() {
 			DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(namespace, cinderTest.MemcachedInstance, memcachedSpec))
 			infra.SimulateMemcachedReady(cinderTest.CinderMemcached)
 			DeferCleanup(keystone.DeleteKeystoneAPI, keystone.CreateKeystoneAPI(cinderTest.Instance.Namespace))
-			mariadb.SimulateMariaDBAccountCompleted(cinderTest.Instance)
-			mariadb.SimulateMariaDBTLSDatabaseCompleted(cinderTest.Instance)
+			mariadb.SimulateMariaDBAccountCompleted(cinderTest.Database)
+			mariadb.SimulateMariaDBTLSDatabaseCompleted(cinderTest.Database)
 			th.SimulateJobSuccess(cinderTest.CinderDBSync)
 		})
 
@@ -678,7 +678,7 @@ var _ = Describe("Cinder controller", func() {
 			harness.Setup(
 				"Cinder",
 				cinderTest.Instance.Namespace,
-				cinderTest.Instance.Name,
+				cinder.DatabaseName,
 				"openstack.org/cinder",
 				mariadb,
 				timeout,
@@ -712,7 +712,7 @@ var _ = Describe("Cinder controller", func() {
 			infra.SimulateMemcachedReady(cinderTest.CinderMemcached)
 			DeferCleanup(keystone.DeleteKeystoneAPI, keystone.CreateKeystoneAPI(cinderTest.Instance.Namespace))
 			mariadb.SimulateMariaDBAccountCompleted(accountName)
-			mariadb.SimulateMariaDBDatabaseCompleted(cinderTest.Instance)
+			mariadb.SimulateMariaDBDatabaseCompleted(cinderTest.Database)
 			th.SimulateJobSuccess(cinderTest.CinderDBSync)
 
 			DeferCleanup(k8sClient.Delete, ctx, th.CreateCABundleSecret(cinderTest.CABundleSecret))

--- a/test/functional/cinder_test_data.go
+++ b/test/functional/cinder_test_data.go
@@ -20,6 +20,7 @@ package functional
 import (
 	"fmt"
 
+	"github.com/openstack-k8s-operators/cinder-operator/pkg/cinder"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -65,6 +66,7 @@ type CinderTestData struct {
 	CABundleSecret         types.NamespacedName
 	InternalCertSecret     types.NamespacedName
 	PublicCertSecret       types.NamespacedName
+	Database               types.NamespacedName
 }
 
 // GetCinderTestData is a function that initialize the CinderTestData
@@ -115,7 +117,7 @@ func GetCinderTestData(cinderName types.NamespacedName) CinderTestData {
 		},
 		CinderTransportURL: types.NamespacedName{
 			Namespace: cinderName.Namespace,
-			Name:      fmt.Sprintf("cinder-%s-transport", cinderName.Name),
+			Name:      fmt.Sprintf("%s-cinder-transport", cinderName.Name),
 		},
 		CinderMemcached: types.NamespacedName{
 			Namespace: cinderName.Namespace,
@@ -132,19 +134,19 @@ func GetCinderTestData(cinderName types.NamespacedName) CinderTestData {
 		// Also used to identify CinderRoutePublic
 		CinderServicePublic: types.NamespacedName{
 			Namespace: cinderName.Namespace,
-			Name:      fmt.Sprintf("%s-public", cinderName.Name),
+			Name:      fmt.Sprintf("%s-public", cinder.ServiceName),
 		},
 		CinderServiceInternal: types.NamespacedName{
 			Namespace: cinderName.Namespace,
-			Name:      fmt.Sprintf("%s-internal", cinderName.Name),
+			Name:      fmt.Sprintf("%s-internal", cinder.ServiceName),
 		},
 		CinderKeystoneService: types.NamespacedName{
 			Namespace: cinderName.Namespace,
-			Name:      fmt.Sprintf("%sv3", cinderName.Name),
+			Name:      cinder.ServiceNameV3,
 		},
 		CinderKeystoneEndpoint: types.NamespacedName{
 			Namespace: cinderName.Namespace,
-			Name:      fmt.Sprintf("%sv3", cinderName.Name),
+			Name:      cinder.ServiceNameV3,
 		},
 		InternalAPINAD: types.NamespacedName{
 			Namespace: cinderName.Namespace,
@@ -170,6 +172,10 @@ func GetCinderTestData(cinderName types.NamespacedName) CinderTestData {
 		PublicCertSecret: types.NamespacedName{
 			Namespace: cinderName.Namespace,
 			Name:      PublicCertSecretName,
+		},
+		Database: types.NamespacedName{
+			Namespace: cinderName.Namespace,
+			Name:      cinder.DatabaseName,
 		},
 	}
 }

--- a/test/functional/suite_test.go
+++ b/test/functional/suite_test.go
@@ -262,7 +262,7 @@ var _ = BeforeEach(func() {
 	// we run the test in an existing cluster.
 	cinderName = types.NamespacedName{
 		Namespace: namespace,
-		Name:      "cinder",
+		Name:      "cinder-" + uuid.NewString()[:5],
 	}
 
 	cinderTest = GetCinderTestData(cinderName)


### PR DESCRIPTION
When the Cinder CR is created using a name that is not "cinder" the `backend` label in the StatefulSet and the final cinder volume Pod will have the wrong value.

This is because the code that determines the backend name in the cinder volume controller doesn't have access to the actual name, so it tries to figure it out from the name of the CinderVolume CR, but since the name no longer starts with `cinder-volume`, then the value is wrong.

This patch changes the way we do this, and now the cinder-operator adds a label to the CinderVolume CR with the name of the backend, then the cinder volume controller uses it to pass it to the statefulset .

Jira: [OSPRH-7396](https://issues.redhat.com//browse/OSPRH-7396)