### PR TITLE
Revert mysql wsrep sync wait

### DIFF
--- a/templates/cinder/config/00-global-defaults.conf
+++ b/templates/cinder/config/00-global-defaults.conf
@@ -41,11 +41,10 @@ connection = {{ .DatabaseConnection }}
 max_retries = -1
 db_max_retries = -1
 
-# Wait for writes to complete when doing reads
-# Relevant for multi-master deployments so that workers table, and possibly
-# other tables, work as intended
+# Wait for writes to complete when doing a read, update, or insert
+# Relevant for multi-master deployments so that workers table works as intended
 # https://mariadb.com/docs/server/ref/mdb/system-variables/wsrep_sync_wait/
-mysql_wsrep_sync_wait = 1
+mysql_wsrep_sync_wait = 7
 
 [os_brick]
 lock_path = /var/locks/openstack/os-brick

--- a/templates/cinder/config/00-global-defaults.conf
+++ b/templates/cinder/config/00-global-defaults.conf
@@ -41,11 +41,6 @@ connection = {{ .DatabaseConnection }}
 max_retries = -1
 db_max_retries = -1
 
-# Wait for writes to complete when doing a read, update, or insert
-# Relevant for multi-master deployments so that workers table works as intended
-# https://mariadb.com/docs/server/ref/mdb/system-variables/wsrep_sync_wait/
-mysql_wsrep_sync_wait = 7
-
 [os_brick]
 lock_path = /var/locks/openstack/os-brick
 


### PR DESCRIPTION
The openstack-k8s-operators/mariadb-operator#229 switched the mariadb-operator to deploy in Active/Passive mode per default, instead of multimaster.