### PR TITLE
Fix attaching encrypted volume on controller nodes

### DIFF
--- a/templates/cinder/config/cinder-backup-config.json
+++ b/templates/cinder/config/cinder-backup-config.json
@@ -27,6 +27,12 @@
     },
     {
       "source": "/usr/local/bin/container-scripts/run-on-host",
+      "dest": "/usr/sbin/cryptsetup",
+      "owner": "root:root",
+      "perm": "0755"
+    },
+    {
+      "source": "/usr/local/bin/container-scripts/run-on-host",
       "dest": "/usr/sbin/nvme",
       "owner": "root:root",
       "perm": "0755"

--- a/templates/cinder/config/cinder-volume-config.json
+++ b/templates/cinder/config/cinder-volume-config.json
@@ -27,6 +27,12 @@
     },
     {
       "source": "/usr/local/bin/container-scripts/run-on-host",
+      "dest": "/usr/sbin/cryptsetup",
+      "owner": "root:root",
+      "perm": "0755"
+    },
+    {
+      "source": "/usr/local/bin/container-scripts/run-on-host",
       "dest": "/usr/sbin/nvme",
       "owner": "root:root",
       "perm": "0755"

--- a/templates/cinder/config/cinder-volume-lvm-config.json
+++ b/templates/cinder/config/cinder-volume-lvm-config.json
@@ -27,6 +27,12 @@
     },
     {
       "source": "/usr/local/bin/container-scripts/run-on-host",
+      "dest": "/usr/sbin/cryptsetup",
+      "owner": "root:root",
+      "perm": "0755"
+    },
+    {
+      "source": "/usr/local/bin/container-scripts/run-on-host",
       "dest": "/usr/sbin/lvm",
       "owner": "root:root",
       "perm": "0755"


### PR DESCRIPTION
Just like with iscsiadm and other command tools there is a need to run the command on the host's namespace.

If we don't run it like that the command will get stuck in:
```
  cryptsetup luksOpen --key-file=- /dev/dm-8 crypt-os-brick+dev+dm-8
```
And if we manually run the command with debug option (`--debug --verbose`) we'll see that it gets stuck in:
```
  # Udev cookie 0xd4d73ad (semid 3) waiting for zero
```
And is unable to continue with the rest:
```
  # Udev cookie 0xd4d3938 (semid 3) destroyed
  # Releasing crypt device /dev/mapper/3600140584b9fc02da024f9c8130ce253 context.
  # Releasing device-mapper backend.
  # Closing read only fd for /dev/mapper/3600140584b9fc02da024f9c8130ce253.
  Command successful.
```
This patch ensure we use `nsenter` to run `cryptsetup`.