### PR TITLE
Update backend samples using custom images

### DIFF
--- a/config/samples/backends/README.md
+++ b/config/samples/backends/README.md
@@ -74,13 +74,13 @@ changes.
 
 Some backends, like 3PAR and Pure, require a custom container because they have
 external dependencies. So there is a need to build a specific container. In
-RHOSP, vendors will provide certified containers through Red Hat's container
+RHOSO, vendors will provide certified containers through Red Hat's container
 image registry. For illustration and development purposes this repository
 provides samples of what a `Dockerfile` would look like for each of the
 vendor's. This `Dockerfile` will be present in the vendor's directory (e.g.
 `hpe/Dockerfile` and `pure/Dockerfile`), so we would need to build a container,
 make it available in a registry, and then provide it to the cinder operator via
-the `containerImage` as seen in the samples.
+the `OpenStackVersion` CR as seen in the samples.
 
 ## Ceph example
 

--- a/config/samples/backends/hpe/3par/fc/backend.yaml
+++ b/config/samples/backends/hpe/3par/fc/backend.yaml
@@ -20,8 +20,6 @@ spec:
         hpe3par-fc:
           networkAttachments:
           - storage
-          # This image exists and was built using the Dockerfile available in the grandparent directory
-          containerImage: quay.io/geguileo/podified-antelope-openstack-cinder-volume-3par:current-podified
           customServiceConfigSecrets:
             - cinder-volume-3par-secrets
           customServiceConfig: |

--- a/config/samples/backends/hpe/3par/fc/custom-container.yaml
+++ b/config/samples/backends/hpe/3par/fc/custom-container.yaml
@@ -1,0 +1,9 @@
+apiVersion: core.openstack.org/v1beta1
+kind: OpenStackVersion
+metadata:
+  name: openstack
+spec:
+  customContainerImages:
+    cinderVolumeImages:
+      # This image exists and was built using the Dockerfile available in the grandparent directory
+      hpe3par-fc: quay.io/geguileo/podified-antelope-openstack-cinder-volume-3par:current-podified

--- a/config/samples/backends/hpe/3par/fc/kustomization.yaml
+++ b/config/samples/backends/hpe/3par/fc/kustomization.yaml
@@ -2,5 +2,6 @@ resources:
   - ../../../bases/multipathd
   - ../../../bases/openstack
   - cinder-volume-3par-secrets.yaml
+  - custom-container.yaml
 patches:
   - path: backend.yaml

--- a/config/samples/backends/hpe/3par/iscsi/backend.yaml
+++ b/config/samples/backends/hpe/3par/iscsi/backend.yaml
@@ -20,8 +20,6 @@ spec:
         hpe3par-iscsi:
           networkAttachments:
           - storage
-          # This image exists and was built using the Dockerfile available in the grandparent directory
-          containerImage: quay.io/geguileo/podified-antelope-openstack-cinder-volume-3par:current-podified
           customServiceConfigSecrets:
             - cinder-volume-3par-secrets
           customServiceConfig: |

--- a/config/samples/backends/hpe/3par/iscsi/custom-container.yaml
+++ b/config/samples/backends/hpe/3par/iscsi/custom-container.yaml
@@ -1,0 +1,9 @@
+apiVersion: core.openstack.org/v1beta1
+kind: OpenStackVersion
+metadata:
+  name: openstack
+spec:
+  customContainerImages:
+    cinderVolumeImages:
+      # This image exists and was built using the Dockerfile available in the grandparent directory
+      hpe3par-iscsi: quay.io/geguileo/podified-antelope-openstack-cinder-volume-3par:current-podified

--- a/config/samples/backends/hpe/3par/iscsi/kustomization.yaml
+++ b/config/samples/backends/hpe/3par/iscsi/kustomization.yaml
@@ -2,6 +2,7 @@ resources:
   - ../../../bases/iscsid
   - ../../../bases/multipathd
   - ../../../bases/openstack
+  - custom-container.yaml
   - cinder-volume-3par-secrets.yaml
 patches:
   - path: backend.yaml

--- a/config/samples/backends/pure/fc/backend.yaml
+++ b/config/samples/backends/pure/fc/backend.yaml
@@ -20,8 +20,6 @@ spec:
         pure-fc:
           networkAttachments:
           - storage
-          # This image exists and was built using the Dockerfile available in the parent directory
-          containerImage: quay.io/geguileo/podified-antelope-openstack-cinder-volume-pure:current-podified
           # Configuration details available at
           # https://pure-storage-openstack-docs.readthedocs.io/en/latest/cinder/ch_cinder-configuration.html
           customServiceConfigSecrets:

--- a/config/samples/backends/pure/fc/custom-container.yaml
+++ b/config/samples/backends/pure/fc/custom-container.yaml
@@ -1,0 +1,9 @@
+apiVersion: core.openstack.org/v1beta1
+kind: OpenStackVersion
+metadata:
+  name: openstack
+spec:
+  customContainerImages:
+    cinderVolumeImages:
+      # This image exists and was built using the Dockerfile available in the parent directory
+      pure-fc: quay.io/geguileo/podified-antelope-openstack-cinder-volume-pure:current-podified

--- a/config/samples/backends/pure/fc/kustomization.yaml
+++ b/config/samples/backends/pure/fc/kustomization.yaml
@@ -1,6 +1,7 @@
 resources:
   - ../../bases/multipathd
   - ../../bases/openstack
+  - custom-container.yaml
   - cinder-volume-pure-secrets.yaml
 patches:
   - path: backend.yaml

--- a/config/samples/backends/pure/iscsi/backend.yaml
+++ b/config/samples/backends/pure/iscsi/backend.yaml
@@ -20,8 +20,6 @@ spec:
         pure-iscsi:
           networkAttachments:
           - storage
-          # This image exists and was built using the Dockerfile available in the parent directory
-          containerImage: quay.io/geguileo/podified-antelope-openstack-cinder-volume-pure:current-podified
           # Configuration details available at
           # https://pure-storage-openstack-docs.readthedocs.io/en/latest/cinder/ch_cinder-configuration.html
           customServiceConfigSecrets:

--- a/config/samples/backends/pure/iscsi/custom-container.yaml
+++ b/config/samples/backends/pure/iscsi/custom-container.yaml
@@ -1,0 +1,9 @@
+apiVersion: core.openstack.org/v1beta1
+kind: OpenStackVersion
+metadata:
+  name: openstack
+spec:
+  customContainerImages:
+    cinderVolumeImages:
+      # This image exists and was built using the Dockerfile available in the grandparent directory
+      pure-iscsi: quay.io/geguileo/podified-antelope-openstack-cinder-volume-3par:current-podified

--- a/config/samples/backends/pure/iscsi/kustomization.yaml
+++ b/config/samples/backends/pure/iscsi/kustomization.yaml
@@ -2,6 +2,7 @@ resources:
   - ../../bases/iscsid
   - ../../bases/multipathd
   - ../../bases/openstack
+  - custom-container.yaml
   - cinder-volume-pure-secrets.yaml
 patches:
   - path: backend.yaml

--- a/config/samples/backends/pure/nvme-roce/backend.yaml
+++ b/config/samples/backends/pure/nvme-roce/backend.yaml
@@ -20,8 +20,6 @@ spec:
         pure-nvme-roce:
           networkAttachments:
           - storage
-          # This image exists and was built using the Dockerfile available in the parent directory
-          containerImage: quay.io/geguileo/podified-antelope-openstack-cinder-volume-pure:current-podified
           # Configuration details available at
           # https://pure-storage-openstack-docs.readthedocs.io/en/latest/cinder/ch_cinder-configuration.html
           customServiceConfigSecrets:

--- a/config/samples/backends/pure/nvme-roce/custom-container.yaml
+++ b/config/samples/backends/pure/nvme-roce/custom-container.yaml
@@ -1,0 +1,9 @@
+apiVersion: core.openstack.org/v1beta1
+kind: OpenStackVersion
+metadata:
+  name: openstack
+spec:
+  customContainerImages:
+    cinderVolumeImages:
+      # This image exists and was built using the Dockerfile available in the grandparent directory
+      pure-nvme-roce: quay.io/geguileo/podified-antelope-openstack-cinder-volume-3par:current-podified

--- a/config/samples/backends/pure/nvme-roce/kustomization.yaml
+++ b/config/samples/backends/pure/nvme-roce/kustomization.yaml
@@ -2,6 +2,7 @@ resources:
   - ../../bases/nvmeof
   - ../../bases/multipathd
   - ../../bases/openstack
+  - custom-container.yaml
   - cinder-volume-pure-secrets.yaml
 patches:
   - path: backend.yaml


### PR DESCRIPTION
Te way custom images are specified has changed, and now it no longer uses the `containerImage` file in the cinder sections but instead needs to be specified in the `OpenStackVersion`.

This patch updates the examples to match the latest code.