### PR TITLE
Remove errorReason from tls input check functional test

### DIFF
--- a/test/functional/cinder_controller_test.go
+++ b/test/functional/cinder_controller_test.go
@@ -484,47 +484,39 @@ var _ = Describe("Cinder controller", func() {
 		})
 
 		It("reports that the CA secret is missing", func() {
-			th.ExpectConditionWithDetails(
+			th.ExpectCondition(
 				cinderTest.CinderAPI,
 				ConditionGetterFunc(CinderAPIConditionGetter),
 				condition.TLSInputReadyCondition,
 				corev1.ConditionFalse,
-				condition.ErrorReason,
-				fmt.Sprintf("TLSInput error occured in TLS sources Secret %s/combined-ca-bundle not found", namespace),
 			)
 
-			th.ExpectConditionWithDetails(
+			th.ExpectCondition(
 				cinderTest.CinderScheduler,
 				ConditionGetterFunc(CinderSchedulerConditionGetter),
 				condition.TLSInputReadyCondition,
 				corev1.ConditionFalse,
-				condition.ErrorReason,
-				fmt.Sprintf("TLSInput error occured in TLS sources Secret %s/combined-ca-bundle not found", namespace),
 			)
 		})
 
 		It("reports that the internal cert secret is missing", func() {
 			DeferCleanup(k8sClient.Delete, ctx, th.CreateCABundleSecret(cinderTest.CABundleSecret))
-			th.ExpectConditionWithDetails(
+			th.ExpectCondition(
 				cinderTest.CinderAPI,
 				ConditionGetterFunc(CinderAPIConditionGetter),
 				condition.TLSInputReadyCondition,
 				corev1.ConditionFalse,
-				condition.ErrorReason,
-				fmt.Sprintf("TLSInput error occured in TLS sources Secret %s/internal-tls-certs not found", namespace),
 			)
 		})
 
 		It("reports that the public cert secret is missing", func() {
 			DeferCleanup(k8sClient.Delete, ctx, th.CreateCABundleSecret(cinderTest.CABundleSecret))
 			DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(cinderTest.InternalCertSecret))
-			th.ExpectConditionWithDetails(
+			th.ExpectCondition(
 				cinderTest.CinderAPI,
 				ConditionGetterFunc(CinderAPIConditionGetter),
 				condition.TLSInputReadyCondition,
 				corev1.ConditionFalse,
-				condition.ErrorReason,
-				fmt.Sprintf("TLSInput error occured in TLS sources Secret %s/public-tls-certs not found", namespace),
 			)
 		})
 


### PR DESCRIPTION
As done for manila, we're not really interested in the `ErrorReason` in functional tests as we depends on what is provided by `lib-common`. However, We still want to match the resulting condition boolean.
This patch removes the `TLSInput` `error message` so we don't fail if something changes in `lib-common`.