### PR TITLE
Ensure nodeSelector logic is consistent for all operators

### DIFF
--- a/api/v1beta1/cinder_types.go
+++ b/api/v1beta1/cinder_types.go
@@ -93,7 +93,7 @@ type CinderSpecBase struct {
 	// NodeSelector to target subset of worker nodes running this service. Setting
 	// NodeSelector here acts as a default value and can be overridden by service
 	// specific NodeSelector Settings.
-	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+	NodeSelector *map[string]string `json:"nodeSelector,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// DBPurge parameters -

--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -49,7 +49,7 @@ type CinderServiceTemplate struct {
 	// +kubebuilder:validation:Optional
 	// NodeSelector to target subset of worker nodes running this service. Setting here overrides
 	// any global NodeSelector settings within the Cinder CR.
-	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+	NodeSelector *map[string]string `json:"nodeSelector,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// CustomServiceConfig - customize the service config using this parameter to change service defaults,

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -671,9 +671,13 @@ func (in *CinderServiceTemplate) DeepCopyInto(out *CinderServiceTemplate) {
 	*out = *in
 	if in.NodeSelector != nil {
 		in, out := &in.NodeSelector, &out.NodeSelector
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
+		*out = new(map[string]string)
+		if **in != nil {
+			in, out := *in, *out
+			*out = make(map[string]string, len(*in))
+			for key, val := range *in {
+				(*out)[key] = val
+			}
 		}
 	}
 	if in.CustomServiceConfigSecrets != nil {
@@ -738,9 +742,13 @@ func (in *CinderSpecBase) DeepCopyInto(out *CinderSpecBase) {
 	}
 	if in.NodeSelector != nil {
 		in, out := &in.NodeSelector, &out.NodeSelector
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
+		*out = new(map[string]string)
+		if **in != nil {
+			in, out := *in, *out
+			*out = make(map[string]string, len(*in))
+			for key, val := range *in {
+				(*out)[key] = val
+			}
 		}
 	}
 	out.DBPurge = in.DBPurge

--- a/controllers/cinder_controller.go
+++ b/controllers/cinder_controller.go
@@ -1014,6 +1014,10 @@ func (r *CinderReconciler) apiDeploymentCreateOrUpdate(ctx context.Context, inst
 		ServiceAccount:     instance.RbacResourceName(),
 	}
 
+	if cinderAPISpec.NodeSelector == nil {
+		cinderAPISpec.NodeSelector = instance.Spec.NodeSelector
+	}
+
 	deployment := &cinderv1beta1.CinderAPI{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-api", instance.Name),
@@ -1023,9 +1027,6 @@ func (r *CinderReconciler) apiDeploymentCreateOrUpdate(ctx context.Context, inst
 
 	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, deployment, func() error {
 		deployment.Spec = cinderAPISpec
-		if len(deployment.Spec.NodeSelector) == 0 {
-			deployment.Spec.NodeSelector = instance.Spec.NodeSelector
-		}
 
 		err := controllerutil.SetControllerReference(instance, deployment, r.Scheme)
 		if err != nil {
@@ -1049,6 +1050,10 @@ func (r *CinderReconciler) schedulerDeploymentCreateOrUpdate(ctx context.Context
 		TLS:                     instance.Spec.CinderAPI.TLS.Ca,
 	}
 
+	if cinderSchedulerSpec.NodeSelector == nil {
+		cinderSchedulerSpec.NodeSelector = instance.Spec.NodeSelector
+	}
+
 	deployment := &cinderv1beta1.CinderScheduler{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-scheduler", instance.Name),
@@ -1058,9 +1063,6 @@ func (r *CinderReconciler) schedulerDeploymentCreateOrUpdate(ctx context.Context
 
 	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, deployment, func() error {
 		deployment.Spec = cinderSchedulerSpec
-		if len(deployment.Spec.NodeSelector) == 0 {
-			deployment.Spec.NodeSelector = instance.Spec.NodeSelector
-		}
 
 		err := controllerutil.SetControllerReference(instance, deployment, r.Scheme)
 		if err != nil {
@@ -1084,6 +1086,10 @@ func (r *CinderReconciler) backupDeploymentCreateOrUpdate(ctx context.Context, i
 		TLS:                  instance.Spec.CinderAPI.TLS.Ca,
 	}
 
+	if cinderBackupSpec.NodeSelector == nil {
+		cinderBackupSpec.NodeSelector = instance.Spec.NodeSelector
+	}
+
 	deployment := &cinderv1beta1.CinderBackup{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-backup", instance.Name),
@@ -1093,9 +1099,6 @@ func (r *CinderReconciler) backupDeploymentCreateOrUpdate(ctx context.Context, i
 
 	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, deployment, func() error {
 		deployment.Spec = cinderBackupSpec
-		if len(deployment.Spec.NodeSelector) == 0 {
-			deployment.Spec.NodeSelector = instance.Spec.NodeSelector
-		}
 
 		err := controllerutil.SetControllerReference(instance, deployment, r.Scheme)
 		if err != nil {
@@ -1146,6 +1149,10 @@ func (r *CinderReconciler) volumeDeploymentCreateOrUpdate(ctx context.Context, i
 		TLS:                  instance.Spec.CinderAPI.TLS.Ca,
 	}
 
+	if cinderVolumeSpec.CinderVolumeTemplate.NodeSelector == nil {
+		cinderVolumeSpec.CinderVolumeTemplate.NodeSelector = instance.Spec.NodeSelector
+	}
+
 	deployment := &cinderv1beta1.CinderVolume{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-volume-%s", instance.Name, name),
@@ -1156,12 +1163,6 @@ func (r *CinderReconciler) volumeDeploymentCreateOrUpdate(ctx context.Context, i
 
 	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, deployment, func() error {
 		deployment.Spec = cinderVolumeSpec
-
-		// If NodeSelector is not specified in volumeTemplate, the current
-		// cinder-volume instance inherits the value from the top-level CR
-		if len(volTemplate.NodeSelector) == 0 {
-			deployment.Spec.NodeSelector = instance.Spec.NodeSelector
-		}
 
 		err := controllerutil.SetControllerReference(instance, deployment, r.Scheme)
 		if err != nil {

--- a/pkg/cinder/cronjob.go
+++ b/pkg/cinder/cronjob.go
@@ -134,8 +134,10 @@ func CronJob(
 			},
 		},
 	}
-	if instance.Spec.NodeSelector != nil && len(instance.Spec.NodeSelector) > 0 {
-		cronjob.Spec.JobTemplate.Spec.Template.Spec.NodeSelector = instance.Spec.NodeSelector
+
+	if instance.Spec.NodeSelector != nil && len(*instance.Spec.NodeSelector) > 0 {
+		cronjob.Spec.JobTemplate.Spec.Template.Spec.NodeSelector = *instance.Spec.NodeSelector
 	}
+
 	return cronjob
 }

--- a/pkg/cinder/cronjob.go
+++ b/pkg/cinder/cronjob.go
@@ -135,7 +135,7 @@ func CronJob(
 		},
 	}
 
-	if instance.Spec.NodeSelector != nil && len(*instance.Spec.NodeSelector) > 0 {
+	if instance.Spec.NodeSelector != nil {
 		cronjob.Spec.JobTemplate.Spec.Template.Spec.NodeSelector = *instance.Spec.NodeSelector
 	}
 

--- a/pkg/cinder/dbsync.go
+++ b/pkg/cinder/dbsync.go
@@ -115,7 +115,7 @@ func DbSyncJob(instance *cinderv1beta1.Cinder, labels map[string]string, annotat
 		},
 	}
 
-	if instance.Spec.NodeSelector != nil && len(*instance.Spec.NodeSelector) > 0 {
+	if instance.Spec.NodeSelector != nil {
 		job.Spec.Template.Spec.NodeSelector = *instance.Spec.NodeSelector
 	}
 

--- a/pkg/cinder/dbsync.go
+++ b/pkg/cinder/dbsync.go
@@ -115,5 +115,9 @@ func DbSyncJob(instance *cinderv1beta1.Cinder, labels map[string]string, annotat
 		},
 	}
 
+	if instance.Spec.NodeSelector != nil && len(*instance.Spec.NodeSelector) > 0 {
+		job.Spec.Template.Spec.NodeSelector = *instance.Spec.NodeSelector
+	}
+
 	return job
 }

--- a/pkg/cinderapi/statefuleset.go
+++ b/pkg/cinderapi/statefuleset.go
@@ -172,7 +172,7 @@ func StatefulSet(
 		},
 	}
 
-	if instance.Spec.NodeSelector != nil && len(*instance.Spec.NodeSelector) > 0 {
+	if instance.Spec.NodeSelector != nil {
 		statefulset.Spec.Template.Spec.NodeSelector = *instance.Spec.NodeSelector
 	}
 

--- a/pkg/cinderapi/statefuleset.go
+++ b/pkg/cinderapi/statefuleset.go
@@ -165,12 +165,15 @@ func StatefulSet(
 							LivenessProbe:  livenessProbe,
 						},
 					},
-					Affinity:     cinder.GetPodAffinity(ComponentName),
-					NodeSelector: instance.Spec.NodeSelector,
-					Volumes:      volumes,
+					Affinity: cinder.GetPodAffinity(ComponentName),
+					Volumes:  volumes,
 				},
 			},
 		},
+	}
+
+	if instance.Spec.NodeSelector != nil && len(*instance.Spec.NodeSelector) > 0 {
+		statefulset.Spec.Template.Spec.NodeSelector = *instance.Spec.NodeSelector
 	}
 
 	return statefulset, nil

--- a/pkg/cinderbackup/statefulset.go
+++ b/pkg/cinderbackup/statefulset.go
@@ -153,7 +153,7 @@ func StatefulSet(
 		},
 	}
 
-	if instance.Spec.NodeSelector != nil && len(*instance.Spec.NodeSelector) > 0 {
+	if instance.Spec.NodeSelector != nil {
 		statefulset.Spec.Template.Spec.NodeSelector = *instance.Spec.NodeSelector
 	}
 

--- a/pkg/cinderbackup/statefulset.go
+++ b/pkg/cinderbackup/statefulset.go
@@ -146,12 +146,15 @@ func StatefulSet(
 							VolumeMounts: volumeMounts,
 						},
 					},
-					Affinity:     cinder.GetPodAffinity(ComponentName),
-					NodeSelector: instance.Spec.NodeSelector,
-					Volumes:      volumes,
+					Affinity: cinder.GetPodAffinity(ComponentName),
+					Volumes:  volumes,
 				},
 			},
 		},
+	}
+
+	if instance.Spec.NodeSelector != nil && len(*instance.Spec.NodeSelector) > 0 {
+		statefulset.Spec.Template.Spec.NodeSelector = *instance.Spec.NodeSelector
 	}
 
 	return statefulset

--- a/pkg/cinderscheduler/statefulset.go
+++ b/pkg/cinderscheduler/statefulset.go
@@ -131,12 +131,15 @@ func StatefulSet(
 							VolumeMounts: volumeMounts,
 						},
 					},
-					Affinity:     cinder.GetPodAffinity(ComponentName),
-					NodeSelector: instance.Spec.NodeSelector,
-					Volumes:      volumes,
+					Affinity: cinder.GetPodAffinity(ComponentName),
+					Volumes:  volumes,
 				},
 			},
 		},
+	}
+
+	if instance.Spec.NodeSelector != nil && len(*instance.Spec.NodeSelector) > 0 {
+		statefulset.Spec.Template.Spec.NodeSelector = *instance.Spec.NodeSelector
 	}
 
 	return statefulset

--- a/pkg/cinderscheduler/statefulset.go
+++ b/pkg/cinderscheduler/statefulset.go
@@ -138,7 +138,7 @@ func StatefulSet(
 		},
 	}
 
-	if instance.Spec.NodeSelector != nil && len(*instance.Spec.NodeSelector) > 0 {
+	if instance.Spec.NodeSelector != nil {
 		statefulset.Spec.Template.Spec.NodeSelector = *instance.Spec.NodeSelector
 	}
 

--- a/pkg/cindervolume/statefulset.go
+++ b/pkg/cindervolume/statefulset.go
@@ -153,12 +153,15 @@ func StatefulSet(
 							VolumeMounts: volumeMounts,
 						},
 					},
-					Affinity:     cinder.GetPodAffinity(ComponentName),
-					NodeSelector: instance.Spec.NodeSelector,
-					Volumes:      volumes,
+					Affinity: cinder.GetPodAffinity(ComponentName),
+					Volumes:  volumes,
 				},
 			},
 		},
+	}
+
+	if instance.Spec.NodeSelector != nil && len(*instance.Spec.NodeSelector) > 0 {
+		statefulset.Spec.Template.Spec.NodeSelector = *instance.Spec.NodeSelector
 	}
 
 	return statefulset

--- a/pkg/cindervolume/statefulset.go
+++ b/pkg/cindervolume/statefulset.go
@@ -160,7 +160,7 @@ func StatefulSet(
 		},
 	}
 
-	if instance.Spec.NodeSelector != nil && len(*instance.Spec.NodeSelector) > 0 {
+	if instance.Spec.NodeSelector != nil {
 		statefulset.Spec.Template.Spec.NodeSelector = *instance.Spec.NodeSelector
 	}
 

--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -19,6 +19,7 @@ import (
 	"golang.org/x/exp/maps"
 
 	. "github.com/onsi/gomega" //revive:disable:dot-imports
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -224,6 +225,14 @@ func GetCinderScheduler(name types.NamespacedName) *cinderv1.CinderScheduler {
 
 func GetCinderVolume(name types.NamespacedName) *cinderv1.CinderVolume {
 	instance := &cinderv1.CinderVolume{}
+	Eventually(func(g Gomega) {
+		g.Expect(k8sClient.Get(ctx, name, instance)).Should(Succeed())
+	}, timeout, interval).Should(Succeed())
+	return instance
+}
+
+func GetCronJob(name types.NamespacedName) *batchv1.CronJob {
+	instance := &batchv1.CronJob{}
 	Eventually(func(g Gomega) {
 		g.Expect(k8sClient.Get(ctx, name, instance)).Should(Succeed())
 	}, timeout, interval).Should(Succeed())

--- a/test/functional/cinder_test_data.go
+++ b/test/functional/cinder_test_data.go
@@ -51,6 +51,7 @@ type CinderTestData struct {
 	CinderMemcached        types.NamespacedName
 	CinderSA               types.NamespacedName
 	CinderDBSync           types.NamespacedName
+	CinderDBPurge          types.NamespacedName
 	CinderKeystoneService  types.NamespacedName
 	CinderKeystoneEndpoint types.NamespacedName
 	CinderServicePublic    types.NamespacedName
@@ -84,6 +85,10 @@ func GetCinderTestData(cinderName types.NamespacedName) CinderTestData {
 		CinderDBSync: types.NamespacedName{
 			Namespace: cinderName.Namespace,
 			Name:      fmt.Sprintf("%s-db-sync", cinderName.Name),
+		},
+		CinderDBPurge: types.NamespacedName{
+			Namespace: cinderName.Namespace,
+			Name:      "cinder-db-purge",
 		},
 		CinderAPI: types.NamespacedName{
 			Namespace: cinderName.Namespace,


### PR DESCRIPTION
nodeSelectors are not currently applied consistently across all operators.

Some do not support nodeSelectors at all - will be implemented in this series of pull requests.
Some do not apply them to every pod (jobs/cronjobs esp) - will be resolved in this series of pull requests.
Some do not apply a node selector update correctly, only when not initially set.
Some support nodeSelectors but do not inherit the default nodeSelector from the OpenstackControlPlane CR.

Jira: [OSPRH-10734](https://issues.redhat.com//browse/OSPRH-10734)