### PR TITLE
Add extraMounts functional tests

### DIFF
--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -296,3 +296,37 @@ func CinderVolumeNotExists(name types.NamespacedName) {
 		g.Expect(k8s_errors.IsNotFound(err)).To(BeTrue())
 	}, timeout, interval).Should(Succeed())
 }
+
+// GetExtraMounts - Utility function that simulates extraMounts pointing
+// to a Ceph secret
+func GetExtraMounts() []map[string]interface{} {
+	return []map[string]interface{}{
+		{
+			"name":   cinderTest.Instance.Name,
+			"region": "az0",
+			"extraVol": []map[string]interface{}{
+				{
+					"extraVolType": CinderCephExtraMountsSecretName,
+					"propagation": []string{
+						"CinderVolume",
+					},
+					"volumes": []map[string]interface{}{
+						{
+							"name": CinderCephExtraMountsSecretName,
+							"secret": map[string]interface{}{
+								"secretName": CinderCephExtraMountsSecretName,
+							},
+						},
+					},
+					"mounts": []map[string]interface{}{
+						{
+							"name":      CinderCephExtraMountsSecretName,
+							"mountPath": CinderCephExtraMountsPath,
+							"readOnly":  true,
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/test/functional/cinder_test_data.go
+++ b/test/functional/cinder_test_data.go
@@ -33,6 +33,10 @@ const (
 	InternalCertSecretName = "internal-tls-certs"
 	//CABundleSecretName -
 	CABundleSecretName = "combined-ca-bundle"
+	// CinderCephExtraMountsPath -
+	CinderCephExtraMountsPath = "/etc/ceph"
+	// CinderCephExtraMountsSecretName -
+	CinderCephExtraMountsSecretName = "ceph"
 )
 
 // CinderTestData is the data structure used to provide input data to envTest


### PR DESCRIPTION
This change adds a functional test for `Cinder` `extraMounts`. It ensures we're able to validate the abstraction of `corev1.VolumeSource` struct introduced in `lib-common/storage` module.

Jira: https://issues.redhat.com/browse/OSPRH-11210