### PR TITLE
Remove localtime hostMount

### DIFF
--- a/pkg/cinder/volumes.go
+++ b/pkg/cinder/volumes.go
@@ -22,14 +22,6 @@ func GetVolumes(name string, storageSvc bool, extraVol []cinderv1beta1.CinderExt
 			},
 		},
 		{
-			Name: "etc-localtime",
-			VolumeSource: corev1.VolumeSource{
-				HostPath: &corev1.HostPathVolumeSource{
-					Path: "/etc/localtime",
-				},
-			},
-		},
-		{
 			Name: "scripts",
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
@@ -162,11 +154,6 @@ func GetVolumeMounts(storageSvc bool, extraVol []cinderv1beta1.CinderExtraVolMou
 		{
 			Name:      "etc-machine-id",
 			MountPath: "/etc/machine-id",
-			ReadOnly:  true,
-		},
-		{
-			Name:      "etc-localtime",
-			MountPath: "/etc/localtime",
 			ReadOnly:  true,
 		},
 		{

--- a/test/functional/cinder_controller_test.go
+++ b/test/functional/cinder_controller_test.go
@@ -606,7 +606,7 @@ var _ = Describe("Cinder controller", func() {
 			d := th.GetStatefulSet(cinderTest.CinderAPI)
 			// Check the resulting deployment fields
 			Expect(int(*d.Spec.Replicas)).To(Equal(1))
-			Expect(d.Spec.Template.Spec.Volumes).To(HaveLen(9))
+			Expect(d.Spec.Template.Spec.Volumes).To(HaveLen(8))
 			Expect(d.Spec.Template.Spec.Containers).To(HaveLen(2))
 
 			// cert deployment volumes
@@ -644,7 +644,7 @@ var _ = Describe("Cinder controller", func() {
 			ss := th.GetStatefulSet(cinderTest.CinderScheduler)
 			// Check the resulting deployment fields
 			Expect(int(*ss.Spec.Replicas)).To(Equal(1))
-			Expect(ss.Spec.Template.Spec.Volumes).To(HaveLen(6))
+			Expect(ss.Spec.Template.Spec.Volumes).To(HaveLen(5))
 			Expect(ss.Spec.Template.Spec.Containers).To(HaveLen(2))
 
 			// cert deployment volumes

--- a/test/kuttl/common/assert_sample_deployment.yaml
+++ b/test/kuttl/common/assert_sample_deployment.yaml
@@ -111,9 +111,6 @@ spec:
         - mountPath: /etc/machine-id
           name: etc-machine-id
           readOnly: true
-        - mountPath: /etc/localtime
-          name: etc-localtime
-          readOnly: true
         - mountPath: /usr/local/bin/container-scripts
           name: scripts
           readOnly: true
@@ -142,10 +139,6 @@ spec:
           path: /etc/machine-id
           type: ""
         name: etc-machine-id
-      - hostPath:
-          path: /etc/localtime
-          type: ""
-        name: etc-localtime
       - secret:
           defaultMode: 493
           secretName: cinder-scripts

--- a/test/kuttl/common/assert_tls_sample_deployment.yaml
+++ b/test/kuttl/common/assert_tls_sample_deployment.yaml
@@ -73,9 +73,6 @@ spec:
         - mountPath: /etc/machine-id
           name: etc-machine-id
           readOnly: true
-        - mountPath: /etc/localtime
-          name: etc-localtime
-          readOnly: true
         - mountPath: /usr/local/bin/container-scripts
           name: scripts
           readOnly: true
@@ -120,10 +117,6 @@ spec:
           path: /etc/machine-id
           type: ""
         name: etc-machine-id
-      - hostPath:
-          path: /etc/localtime
-          type: ""
-        name: etc-localtime
       - name: scripts
         secret:
           defaultMode: 493
@@ -169,9 +162,6 @@ spec:
         - mountPath: /etc/machine-id
           name: etc-machine-id
           readOnly: true
-        - mountPath: /etc/localtime
-          name: etc-localtime
-          readOnly: true
         - mountPath: /usr/local/bin/container-scripts
           name: scripts
           readOnly: true
@@ -203,9 +193,6 @@ spec:
         - mountPath: /etc/machine-id
           name: etc-machine-id
           readOnly: true
-        - mountPath: /etc/localtime
-          name: etc-localtime
-          readOnly: true
         - mountPath: /usr/local/bin/container-scripts
           name: scripts
           readOnly: true
@@ -232,10 +219,6 @@ spec:
           path: /etc/machine-id
           type: ""
         name: etc-machine-id
-      - hostPath:
-          path: /etc/localtime
-          type: ""
-        name: etc-localtime
       - name: scripts
         secret:
           defaultMode: 493
@@ -270,9 +253,6 @@ spec:
         volumeMounts:
         - mountPath: /etc/machine-id
           name: etc-machine-id
-          readOnly: true
-        - mountPath: /etc/localtime
-          name: etc-localtime
           readOnly: true
         - mountPath: /usr/local/bin/container-scripts
           name: scripts
@@ -323,9 +303,6 @@ spec:
         - mountPath: /etc/machine-id
           name: etc-machine-id
           readOnly: true
-        - mountPath: /etc/localtime
-          name: etc-localtime
-          readOnly: true
         - mountPath: /usr/local/bin/container-scripts
           name: scripts
           readOnly: true
@@ -372,10 +349,6 @@ spec:
           path: /etc/machine-id
           type: ""
         name: etc-machine-id
-      - hostPath:
-          path: /etc/localtime
-          type: ""
-        name: etc-localtime
       - name: scripts
         secret:
           defaultMode: 493


### PR DESCRIPTION
`Cinder` `Pods` shouldn't inherit `/etc/localtime` from the worker node/host where the `Pod` is scheduled. Mounting that volume has several drawbacks, and one of them is having these Pods not aligned with the rest of the control plane other than establish a dependency with the underlying host.
It results difficult to track requests in case of troubleshooting and as per [1] the current approach is not recommended.
Because there is no reason to modify `localtime` to match the underlying host, this patch fixes the reported bug by removing it.

Jira: https://issues.redhat.com/browse/OSPRH-17676

[1] https://access.redhat.com/solutions/5487331