### PR TITLE
Fix notificationsBusInstance typo in the API parameter

### DIFF
--- a/api/bases/cinder.openstack.org_cinderapis.yaml
+++ b/api/bases/cinder.openstack.org_cinderapis.yaml
@@ -1158,8 +1158,8 @@ spec:
                   NodeSelector to target subset of worker nodes running this service. Setting here overrides
                   any global NodeSelector settings within the Cinder CR.
                 type: object
-              notificationURLSecret:
-                description: Secret containing Notification transport URL
+              notificationsURLSecret:
+                description: Secret containing Notifications transport URL
                 type: string
               override:
                 description: Override, provides the ability to override the generated

--- a/api/bases/cinder.openstack.org_cinderbackups.yaml
+++ b/api/bases/cinder.openstack.org_cinderbackups.yaml
@@ -1158,8 +1158,8 @@ spec:
                   NodeSelector to target subset of worker nodes running this service. Setting here overrides
                   any global NodeSelector settings within the Cinder CR.
                 type: object
-              notificationURLSecret:
-                description: Secret containing Notification transport URL
+              notificationsURLSecret:
+                description: Secret containing Notifications transport URL
                 type: string
               passwordSelectors:
                 default:

--- a/api/bases/cinder.openstack.org_cinders.yaml
+++ b/api/bases/cinder.openstack.org_cinders.yaml
@@ -1830,7 +1830,7 @@ spec:
                   NodeSelector here acts as a default value and can be overridden by service
                   specific NodeSelector Settings.
                 type: object
-              notificationBusInstance:
+              notificationsBusInstance:
                 description: |-
                   RabbitMQ instance name used to request a transportURL that is used for
                   notification purposes
@@ -1975,8 +1975,8 @@ spec:
                   type: string
                 description: Map of hashes to track e.g. job status
                 type: object
-              notificationURLSecret:
-                description: NotificationURLSecret - Secret containing RabbitMQ notificationURL
+              notificationsURLSecret:
+                description: NotificationsURLSecret - Secret containing RabbitMQ notificationsURL
                 type: string
               observedGeneration:
                 description: |-

--- a/api/bases/cinder.openstack.org_cinderschedulers.yaml
+++ b/api/bases/cinder.openstack.org_cinderschedulers.yaml
@@ -1158,8 +1158,8 @@ spec:
                   NodeSelector to target subset of worker nodes running this service. Setting here overrides
                   any global NodeSelector settings within the Cinder CR.
                 type: object
-              notificationURLSecret:
-                description: Secret containing Notification transport URL
+              notificationsURLSecret:
+                description: Secret containing Notifications transport URL
                 type: string
               passwordSelectors:
                 default:

--- a/api/bases/cinder.openstack.org_cindervolumes.yaml
+++ b/api/bases/cinder.openstack.org_cindervolumes.yaml
@@ -1158,8 +1158,8 @@ spec:
                   NodeSelector to target subset of worker nodes running this service. Setting here overrides
                   any global NodeSelector settings within the Cinder CR.
                 type: object
-              notificationURLSecret:
-                description: Secret containing Notification transport URL
+              notificationsURLSecret:
+                description: Secret containing Notifications transport URL
                 type: string
               passwordSelectors:
                 default:

--- a/api/v1beta1/cinder_types.go
+++ b/api/v1beta1/cinder_types.go
@@ -114,7 +114,7 @@ type CinderSpecBase struct {
 	// +kubebuilder:validation:Optional
 	// RabbitMQ instance name used to request a transportURL that is used for
 	// notification purposes
-	NotificationBusInstance *string `json:"notificationBusInstance,omitempty"`
+	NotificationsBusInstance *string `json:"notificationsBusInstance,omitempty"`
 }
 
 // CinderSpecCore the same as CinderSpec without ContainerImage references
@@ -172,8 +172,8 @@ type CinderStatus struct {
 	// TransportURLSecret - Secret containing RabbitMQ transportURL entries
 	TransportURLSecret string `json:"transportURLSecret,omitempty"`
 
-	// NotificationURLSecret - Secret containing RabbitMQ notificationURL
-	NotificationURLSecret *string `json:"notificationURLSecret,omitempty"`
+	// NotificationsURLSecret - Secret containing RabbitMQ notificationsURL
+	NotificationsURLSecret *string `json:"notificationsURLSecret,omitempty"`
 
 	// API endpoints
 	APIEndpoints map[string]map[string]string `json:"apiEndpoints,omitempty"`

--- a/api/v1beta1/cinderapi_types.go
+++ b/api/v1beta1/cinderapi_types.go
@@ -77,8 +77,8 @@ type CinderAPISpec struct {
 	// Secret containing RabbitMq transport URL
 	TransportURLSecret string `json:"transportURLSecret"`
 
-	// Secret containing Notification transport URL
-	NotificationURLSecret string `json:"notificationURLSecret,omitempty"`
+	// Secret containing Notifications transport URL
+	NotificationsURLSecret string `json:"notificationsURLSecret,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// ExtraMounts containing conf files and credentials

--- a/api/v1beta1/cinderbackup_types.go
+++ b/api/v1beta1/cinderbackup_types.go
@@ -60,8 +60,8 @@ type CinderBackupSpec struct {
 	// Secret containing RabbitMq transport URL
 	TransportURLSecret string `json:"transportURLSecret"`
 
-	// Secret containing Notification transport URL
-	NotificationURLSecret string `json:"notificationURLSecret,omitempty"`
+	// Secret containing Notifications transport URL
+	NotificationsURLSecret string `json:"notificationsURLSecret,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// ExtraMounts containing conf files and credentials

--- a/api/v1beta1/cinderscheduler_types.go
+++ b/api/v1beta1/cinderscheduler_types.go
@@ -60,8 +60,8 @@ type CinderSchedulerSpec struct {
 	// Secret containing RabbitMq transport URL
 	TransportURLSecret string `json:"transportURLSecret"`
 
-	// Secret containing Notification transport URL
-	NotificationURLSecret string `json:"notificationURLSecret,omitempty"`
+	// Secret containing Notifications transport URL
+	NotificationsURLSecret string `json:"notificationsURLSecret,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// ExtraMounts containing conf files and credentials

--- a/api/v1beta1/cindervolume_types.go
+++ b/api/v1beta1/cindervolume_types.go
@@ -66,8 +66,8 @@ type CinderVolumeSpec struct {
 	// Secret containing RabbitMq transport URL
 	TransportURLSecret string `json:"transportURLSecret"`
 
-	// Secret containing Notification transport URL
-	NotificationURLSecret string `json:"notificationURLSecret,omitempty"`
+	// Secret containing Notifications transport URL
+	NotificationsURLSecret string `json:"notificationsURLSecret,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// ExtraMounts containing conf files and credentials

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -796,8 +796,8 @@ func (in *CinderSpecBase) DeepCopyInto(out *CinderSpecBase) {
 		*out = new(topologyv1beta1.TopoRef)
 		**out = **in
 	}
-	if in.NotificationBusInstance != nil {
-		in, out := &in.NotificationBusInstance, &out.NotificationBusInstance
+	if in.NotificationsBusInstance != nil {
+		in, out := &in.NotificationsBusInstance, &out.NotificationsBusInstance
 		*out = new(string)
 		**out = **in
 	}
@@ -856,8 +856,8 @@ func (in *CinderStatus) DeepCopyInto(out *CinderStatus) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	if in.NotificationURLSecret != nil {
-		in, out := &in.NotificationURLSecret, &out.NotificationURLSecret
+	if in.NotificationsURLSecret != nil {
+		in, out := &in.NotificationsURLSecret, &out.NotificationsURLSecret
 		*out = new(string)
 		**out = **in
 	}

--- a/config/crd/bases/cinder.openstack.org_cinderapis.yaml
+++ b/config/crd/bases/cinder.openstack.org_cinderapis.yaml
@@ -1158,8 +1158,8 @@ spec:
                   NodeSelector to target subset of worker nodes running this service. Setting here overrides
                   any global NodeSelector settings within the Cinder CR.
                 type: object
-              notificationURLSecret:
-                description: Secret containing Notification transport URL
+              notificationsURLSecret:
+                description: Secret containing Notifications transport URL
                 type: string
               override:
                 description: Override, provides the ability to override the generated

--- a/config/crd/bases/cinder.openstack.org_cinderbackups.yaml
+++ b/config/crd/bases/cinder.openstack.org_cinderbackups.yaml
@@ -1158,8 +1158,8 @@ spec:
                   NodeSelector to target subset of worker nodes running this service. Setting here overrides
                   any global NodeSelector settings within the Cinder CR.
                 type: object
-              notificationURLSecret:
-                description: Secret containing Notification transport URL
+              notificationsURLSecret:
+                description: Secret containing Notifications transport URL
                 type: string
               passwordSelectors:
                 default:

--- a/config/crd/bases/cinder.openstack.org_cinders.yaml
+++ b/config/crd/bases/cinder.openstack.org_cinders.yaml
@@ -1830,7 +1830,7 @@ spec:
                   NodeSelector here acts as a default value and can be overridden by service
                   specific NodeSelector Settings.
                 type: object
-              notificationBusInstance:
+              notificationsBusInstance:
                 description: |-
                   RabbitMQ instance name used to request a transportURL that is used for
                   notification purposes
@@ -1975,8 +1975,8 @@ spec:
                   type: string
                 description: Map of hashes to track e.g. job status
                 type: object
-              notificationURLSecret:
-                description: NotificationURLSecret - Secret containing RabbitMQ notificationURL
+              notificationsURLSecret:
+                description: NotificationsURLSecret - Secret containing RabbitMQ notificationsURL
                 type: string
               observedGeneration:
                 description: |-

--- a/config/crd/bases/cinder.openstack.org_cinderschedulers.yaml
+++ b/config/crd/bases/cinder.openstack.org_cinderschedulers.yaml
@@ -1158,8 +1158,8 @@ spec:
                   NodeSelector to target subset of worker nodes running this service. Setting here overrides
                   any global NodeSelector settings within the Cinder CR.
                 type: object
-              notificationURLSecret:
-                description: Secret containing Notification transport URL
+              notificationsURLSecret:
+                description: Secret containing Notifications transport URL
                 type: string
               passwordSelectors:
                 default:

--- a/config/crd/bases/cinder.openstack.org_cindervolumes.yaml
+++ b/config/crd/bases/cinder.openstack.org_cindervolumes.yaml
@@ -1158,8 +1158,8 @@ spec:
                   NodeSelector to target subset of worker nodes running this service. Setting here overrides
                   any global NodeSelector settings within the Cinder CR.
                 type: object
-              notificationURLSecret:
-                description: Secret containing Notification transport URL
+              notificationsURLSecret:
+                description: Secret containing Notifications transport URL
                 type: string
               passwordSelectors:
                 default:

--- a/controllers/cinderapi_controller.go
+++ b/controllers/cinderapi_controller.go
@@ -707,7 +707,7 @@ func (r *CinderAPIReconciler) reconcileNormal(ctx context.Context, instance *cin
 
 	parentCinderName := cinder.GetOwningCinderName(instance)
 	secretNames := []string{
-		instance.Spec.NotificationURLSecret,             // NotificationURLSecret
+		instance.Spec.NotificationsURLSecret,            // NotificationsURLSecret
 		instance.Spec.TransportURLSecret,                // TransportURLSecret
 		fmt.Sprintf("%s-scripts", parentCinderName),     // ScriptsSecret
 		fmt.Sprintf("%s-config-data", parentCinderName), // ConfigSecret

--- a/controllers/cinderbackup_controller.go
+++ b/controllers/cinderbackup_controller.go
@@ -396,7 +396,7 @@ func (r *CinderBackupReconciler) reconcileNormal(ctx context.Context, instance *
 
 	parentCinderName := cinder.GetOwningCinderName(instance)
 	secretNames := []string{
-		instance.Spec.NotificationURLSecret,             // NotificationURLSecret
+		instance.Spec.NotificationsURLSecret,            // NotificationsURLSecret
 		instance.Spec.TransportURLSecret,                // TransportURLSecret
 		fmt.Sprintf("%s-scripts", parentCinderName),     // ScriptsSecret
 		fmt.Sprintf("%s-config-data", parentCinderName), // ConfigSecret

--- a/controllers/cinderscheduler_controller.go
+++ b/controllers/cinderscheduler_controller.go
@@ -394,7 +394,7 @@ func (r *CinderSchedulerReconciler) reconcileNormal(ctx context.Context, instanc
 
 	parentCinderName := cinder.GetOwningCinderName(instance)
 	secretNames := []string{
-		instance.Spec.NotificationURLSecret,             // NotificationURLSecret
+		instance.Spec.NotificationsURLSecret,            // NotificationsURLSecret
 		instance.Spec.TransportURLSecret,                // TransportURLSecret
 		fmt.Sprintf("%s-scripts", parentCinderName),     // ScriptsSecret
 		fmt.Sprintf("%s-config-data", parentCinderName), // ConfigSecret

--- a/controllers/cindervolume_controller.go
+++ b/controllers/cindervolume_controller.go
@@ -397,7 +397,7 @@ func (r *CinderVolumeReconciler) reconcileNormal(ctx context.Context, instance *
 
 	parentCinderName := cinder.GetOwningCinderName(instance)
 	secretNames := []string{
-		instance.Spec.NotificationURLSecret,             // NotificationURLSecret
+		instance.Spec.NotificationsURLSecret,            // NotificationsURLSecret
 		instance.Spec.TransportURLSecret,                // TransportURLSecret
 		fmt.Sprintf("%s-scripts", parentCinderName),     // ScriptsSecret
 		fmt.Sprintf("%s-config-data", parentCinderName), // ConfigSecret

--- a/test/functional/cinder_controller_test.go
+++ b/test/functional/cinder_controller_test.go
@@ -1243,10 +1243,10 @@ var _ = Describe("Cinder controller", func() {
 	When("Cinder instance has notifications enabled", func() {
 		BeforeEach(func() {
 			rawSpec := map[string]interface{}{
-				"secret":                  SecretName,
-				"databaseInstance":        "openstack",
-				"rabbitMqClusterName":     "rabbitmq",
-				"notificationBusInstance": "rabbitmq",
+				"secret":                   SecretName,
+				"databaseInstance":         "openstack",
+				"rabbitMqClusterName":      "rabbitmq",
+				"notificationsBusInstance": "rabbitmq",
 				"cinderAPI": map[string]interface{}{
 					"containerImage": cinderv1.CinderAPIContainerImage,
 				},
@@ -1293,9 +1293,9 @@ var _ = Describe("Cinder controller", func() {
 			Eventually(func(g Gomega) {
 				cinder := GetCinder(cinderTest.Instance)
 				g.Expect(cinder.Status.TransportURLSecret).ToNot(Equal(""))
-				g.Expect(cinder.Status.NotificationURLSecret).ToNot(BeNil())
+				g.Expect(cinder.Status.NotificationsURLSecret).ToNot(BeNil())
 				g.Expect(cinder.Status.TransportURLSecret).To(Equal(
-					*cinder.Status.NotificationURLSecret))
+					*cinder.Status.NotificationsURLSecret))
 			}, timeout, interval).Should(Succeed())
 		})
 		It("overrides cinder CR notifications", func() {
@@ -1305,7 +1305,7 @@ var _ = Describe("Cinder controller", func() {
 			// update cinder CR to point to the new (dedicated) rabbit instance
 			Eventually(func(g Gomega) {
 				cinder := GetCinder(cinderTest.Instance)
-				*cinder.Spec.NotificationBusInstance = "rabbitmq-notification"
+				*cinder.Spec.NotificationsBusInstance = "rabbitmq-notification"
 				g.Expect(k8sClient.Update(ctx, cinder)).To(Succeed())
 			}, timeout, interval).Should(Succeed())
 
@@ -1318,7 +1318,7 @@ var _ = Describe("Cinder controller", func() {
 
 			Eventually(func(g Gomega) {
 				cinder := GetCinder(cinderTest.Instance)
-				g.Expect(*cinder.Status.NotificationURLSecret).ToNot(
+				g.Expect(*cinder.Status.NotificationsURLSecret).ToNot(
 					Equal(cinder.Status.TransportURLSecret))
 			}, timeout, interval).Should(Succeed())
 		})
@@ -1326,13 +1326,13 @@ var _ = Describe("Cinder controller", func() {
 		It("updates cinder CR and disable notifications", func() {
 			Eventually(func(g Gomega) {
 				cinder := GetCinder(cinderTest.Instance)
-				cinder.Spec.NotificationBusInstance = nil
+				cinder.Spec.NotificationsBusInstance = nil
 				g.Expect(k8sClient.Update(ctx, cinder)).To(Succeed())
 			}, timeout, interval).Should(Succeed())
 
 			Eventually(func(g Gomega) {
 				cinder := GetCinder(cinderTest.Instance)
-				g.Expect(cinder.Status.NotificationURLSecret).To(BeNil())
+				g.Expect(cinder.Status.NotificationsURLSecret).To(BeNil())
 				g.Expect(cinder.Status.TransportURLSecret).ToNot(Equal(""))
 			}, timeout, interval).Should(Succeed())
 		})


### PR DESCRIPTION
`Nova` and probably other operators have `notificationsBus` instead of `notificationBus`, which let storage operator to slightly diverge due to the missing final `s`.
This patch fixes the interface (currently present only in main).