### PR TITLE
Use quorum queues if enabled

### DIFF
--- a/controllers/cinder_controller.go
+++ b/controllers/cinder_controller.go
@@ -1014,6 +1014,7 @@ func (r *CinderReconciler) generateServiceConfigs(
 		return err
 	}
 	transportURLSecretData := string(transportURLSecret.Data["transport_url"])
+	transportURLQuorumQueues := string(transportURLSecret.Data["quorumqueues"]) == "true"
 
 	databaseAccount := db.GetAccount()
 	dbSecret := db.GetSecret()
@@ -1032,6 +1033,7 @@ func (r *CinderReconciler) generateServiceConfigs(
 	templateParameters["MemcachedServersWithInet"] = memcached.GetMemcachedServerListWithInetString()
 	templateParameters["MemcachedServers"] = memcached.GetMemcachedServerListString()
 	templateParameters["TimeOut"] = instance.Spec.APITimeout
+	templateParameters["QuorumQueues"] = transportURLQuorumQueues
 
 	// MTLS
 	if memcached.GetMemcachedMTLSSecret() != "" {

--- a/templates/cinder/config/00-global-defaults.conf
+++ b/templates/cinder/config/00-global-defaults.conf
@@ -59,7 +59,11 @@ driver=noop
 
 [oslo_messaging_rabbit]
 heartbeat_timeout_threshold=60
-
+{{ if (index . "QuorumQueues") -}}
+rabbit_quorum_queue=true
+rabbit_transient_quorum_queue=true
+amqp_durable_queues=true
+{{ end }}
 [oslo_middleware]
 enable_proxy_headers_parsing=True
 

--- a/test/functional/cinder_test_data.go
+++ b/test/functional/cinder_test_data.go
@@ -133,7 +133,7 @@ func GetCinderTestData(cinderName types.NamespacedName) CinderTestData {
 		},
 		CinderTransportURLNotification: types.NamespacedName{
 			Namespace: cinderName.Namespace,
-			Name:      fmt.Sprintf("%s-cinder-transport-notification", cinderName.Name),
+			Name:      fmt.Sprintf("%s-cinder-transport-notifications", cinderName.Name),
 		},
 		CinderMemcached: types.NamespacedName{
 			Namespace: cinderName.Namespace,


### PR DESCRIPTION
With https://github.com/openstack-k8s-operators/infra-operator/pull/429 we added the ability to configure RabbitMQ to use quorum queues.

This commit adds a check to verify if "quorumqueues" has been added to the TransportURL secret. If its value is true, the services will be configured to use quorum queues.

Jira: https://issues.redhat.com/browse/OSPRH-19160