### PR TITLE
Update oslo_reports file_event_handler

### DIFF
--- a/templates/cinder/config/00-global-defaults.conf
+++ b/templates/cinder/config/00-global-defaults.conf
@@ -64,7 +64,7 @@ heartbeat_timeout_threshold=60
 enable_proxy_headers_parsing=True
 
 [oslo_reports]
-file_event_handler=/etc/cinder
+file_event_handler=/var/lib/cinder
 
 [keystone_authtoken]
 www_authenticate_uri={{ .KeystonePublicURL }}


### PR DESCRIPTION
With PR [1] root has been removed from `cinder`. As a consequence is not possible to trigger `gmr` with a touch on `/etc/cinder` path anymore [2] because it belongs to the root user.
This patch updates the `file_event_handler` default path to point to `/var/lib/cinder` that we know is _chowned_ to `cinder:cinder` by [3]. 

[1] https://github.com/openstack-k8s-operators/cinder-operator/pull/417
[2] https://docs.openstack.org/cinder/latest/contributor/gmr.html
[3] https://github.com/openstack-k8s-operators/tcib/blob/main/container-images/kolla/base/uid_gid_manage.sh#L40

Jira: https://issues.redhat.com/browse/OSPRH-17882