### PR TITLE
[OSPRH-20095] Improve consistency of condition severity usage

### DIFF
--- a/controllers/cinder_common.go
+++ b/controllers/cinder_common.go
@@ -120,11 +120,13 @@ func verifyServiceSecret(
 			err.Error()))
 		return res, err
 	} else if (res != ctrl.Result{}) {
+		// Since the service secret should have been manually created by the user and referenced in the spec,
+		// we treat this as a warning because it means that the service will not be able to start.
 		log.FromContext(ctx).Info(fmt.Sprintf("OpenStack secret %s not found", secretName))
 		conditionUpdater.Set(condition.FalseCondition(
 			condition.InputReadyCondition,
-			condition.RequestedReason,
-			condition.SeverityInfo,
+			condition.ErrorReason,
+			condition.SeverityWarning,
 			condition.InputReadyWaitingMessage))
 		return res, nil
 	}
@@ -152,11 +154,14 @@ func verifyConfigSecrets(
 		_, hash, err = secret.GetSecret(ctx, h, secretName, namespace)
 		if err != nil {
 			if k8s_errors.IsNotFound(err) {
+				// Since config secrets should have been previously automatically created by the parent
+				// Cinder CR and then referenced in this instance's spec, we treat this as a warning
+				// because it means that the service will not be able to start.
 				log.FromContext(ctx).Info(fmt.Sprintf("Secret %s not found", secretName))
 				conditionUpdater.Set(condition.FalseCondition(
 					condition.InputReadyCondition,
-					condition.RequestedReason,
-					condition.SeverityInfo,
+					condition.ErrorReason,
+					condition.SeverityWarning,
 					condition.InputReadyWaitingMessage))
 				return cinder.ResultRequeue, nil
 			}

--- a/controllers/cinderapi_controller.go
+++ b/controllers/cinderapi_controller.go
@@ -746,10 +746,12 @@ func (r *CinderAPIReconciler) reconcileNormal(ctx context.Context, instance *cin
 		)
 		if err != nil {
 			if k8s_errors.IsNotFound(err) {
+				// Since the CA cert secret should have been manually created by the user and provided in the spec,
+				// we treat this as a warning because it means that the service will not be able to start.
 				instance.Status.Conditions.Set(condition.FalseCondition(
 					condition.TLSInputReadyCondition,
-					condition.RequestedReason,
-					condition.SeverityInfo,
+					condition.ErrorReason,
+					condition.SeverityWarning,
 					condition.TLSInputReadyWaitingMessage, instance.Spec.TLS.CaBundleSecretName))
 				return ctrl.Result{}, nil
 			}
@@ -771,6 +773,8 @@ func (r *CinderAPIReconciler) reconcileNormal(ctx context.Context, instance *cin
 	certsHash, err := instance.Spec.TLS.API.ValidateCertSecrets(ctx, helper, instance.Namespace)
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {
+			// Since the OpenStackControlPlane creates the API service certs secrets,
+			// we treat this as an info (because the user is not responsible for manually creating them).
 			instance.Status.Conditions.Set(condition.FalseCondition(
 				condition.TLSInputReadyCondition,
 				condition.RequestedReason,
@@ -825,11 +829,13 @@ func (r *CinderAPIReconciler) reconcileNormal(ctx context.Context, instance *cin
 		nad, err := nad.GetNADWithName(ctx, helper, netAtt, instance.Namespace)
 		if err != nil {
 			if k8s_errors.IsNotFound(err) {
+				// Since the net-attach-def CR should have been manually created by the user and referenced in the spec,
+				// we treat this as a warning because it means that the service will not be able to start.
 				Log.Info(fmt.Sprintf("network-attachment-definition %s not found", netAtt))
 				instance.Status.Conditions.Set(condition.FalseCondition(
 					condition.NetworkAttachmentsReadyCondition,
-					condition.RequestedReason,
-					condition.SeverityInfo,
+					condition.ErrorReason,
+					condition.SeverityWarning,
 					condition.NetworkAttachmentsReadyWaitingMessage,
 					netAtt))
 				return cinder.ResultRequeue, fmt.Errorf("%w: %s", ErrNetworkAttachmentNotFound, netAtt)

--- a/controllers/cinderbackup_controller.go
+++ b/controllers/cinderbackup_controller.go
@@ -435,10 +435,12 @@ func (r *CinderBackupReconciler) reconcileNormal(ctx context.Context, instance *
 		)
 		if err != nil {
 			if k8s_errors.IsNotFound(err) {
+				// Since the CA cert secret should have been manually created by the user and provided in the spec,
+				// we treat this as a warning because it means that the service will not be able to start.
 				instance.Status.Conditions.Set(condition.FalseCondition(
 					condition.TLSInputReadyCondition,
-					condition.RequestedReason,
-					condition.SeverityInfo,
+					condition.ErrorReason,
+					condition.SeverityWarning,
 					condition.TLSInputReadyWaitingMessage, instance.Spec.TLS.CaBundleSecretName))
 				return ctrl.Result{}, nil
 			}
@@ -516,11 +518,13 @@ func (r *CinderBackupReconciler) reconcileNormal(ctx context.Context, instance *
 		nad, err := nad.GetNADWithName(ctx, helper, netAtt, instance.Namespace)
 		if err != nil {
 			if k8s_errors.IsNotFound(err) {
+				// Since the net-attach-def CR should have been manually created by the user and referenced in the spec,
+				// we treat this as a warning because it means that the service will not be able to start.
 				Log.Info(fmt.Sprintf("network-attachment-definition %s not found", netAtt))
 				instance.Status.Conditions.Set(condition.FalseCondition(
 					condition.NetworkAttachmentsReadyCondition,
-					condition.RequestedReason,
-					condition.SeverityInfo,
+					condition.ErrorReason,
+					condition.SeverityWarning,
 					condition.NetworkAttachmentsReadyWaitingMessage,
 					netAtt))
 				return cinder.ResultRequeue, fmt.Errorf("%w: %s", ErrNetworkAttachmentNotFound, netAtt)

--- a/controllers/cinderscheduler_controller.go
+++ b/controllers/cinderscheduler_controller.go
@@ -433,10 +433,12 @@ func (r *CinderSchedulerReconciler) reconcileNormal(ctx context.Context, instanc
 		)
 		if err != nil {
 			if k8s_errors.IsNotFound(err) {
+				// Since the CA cert secret should have been manually created by the user and provided in the spec,
+				// we treat this as a warning because it means that the service will not be able to start.
 				instance.Status.Conditions.Set(condition.FalseCondition(
 					condition.TLSInputReadyCondition,
-					condition.RequestedReason,
-					condition.SeverityInfo,
+					condition.ErrorReason,
+					condition.SeverityWarning,
 					condition.TLSInputReadyWaitingMessage, instance.Spec.TLS.CaBundleSecretName))
 				return ctrl.Result{}, nil
 			}
@@ -514,11 +516,13 @@ func (r *CinderSchedulerReconciler) reconcileNormal(ctx context.Context, instanc
 		nad, err := nad.GetNADWithName(ctx, helper, netAtt, instance.Namespace)
 		if err != nil {
 			if k8s_errors.IsNotFound(err) {
+				// Since the net-attach-def CR should have been manually created by the user and referenced in the spec,
+				// we treat this as a warning because it means that the service will not be able to start.
 				Log.Info(fmt.Sprintf("network-attachment-definition %s not found", netAtt))
 				instance.Status.Conditions.Set(condition.FalseCondition(
 					condition.NetworkAttachmentsReadyCondition,
-					condition.RequestedReason,
-					condition.SeverityInfo,
+					condition.ErrorReason,
+					condition.SeverityWarning,
 					condition.NetworkAttachmentsReadyWaitingMessage,
 					netAtt))
 				return cinder.ResultRequeue, fmt.Errorf("%w: %s", ErrNetworkAttachmentNotFound, netAtt)

--- a/controllers/cindervolume_controller.go
+++ b/controllers/cindervolume_controller.go
@@ -436,10 +436,12 @@ func (r *CinderVolumeReconciler) reconcileNormal(ctx context.Context, instance *
 		)
 		if err != nil {
 			if k8s_errors.IsNotFound(err) {
+				// Since the CA cert secret should have been manually created by the user and provided in the spec,
+				// we treat this as a warning because it means that the service will not be able to start.
 				instance.Status.Conditions.Set(condition.FalseCondition(
 					condition.TLSInputReadyCondition,
-					condition.RequestedReason,
-					condition.SeverityInfo,
+					condition.ErrorReason,
+					condition.SeverityWarning,
 					condition.TLSInputReadyWaitingMessage, instance.Spec.TLS.CaBundleSecretName))
 				return ctrl.Result{}, nil
 			}
@@ -518,11 +520,13 @@ func (r *CinderVolumeReconciler) reconcileNormal(ctx context.Context, instance *
 		nad, err := nad.GetNADWithName(ctx, helper, netAtt, instance.Namespace)
 		if err != nil {
 			if k8s_errors.IsNotFound(err) {
+				// Since the net-attach-def CR should have been manually created by the user and referenced in the spec,
+				// we treat this as a warning because it means that the service will not be able to start.
 				Log.Info(fmt.Sprintf("network-attachment-definition %s not found", netAtt))
 				instance.Status.Conditions.Set(condition.FalseCondition(
 					condition.NetworkAttachmentsReadyCondition,
-					condition.RequestedReason,
-					condition.SeverityInfo,
+					condition.ErrorReason,
+					condition.SeverityWarning,
 					condition.NetworkAttachmentsReadyWaitingMessage,
 					netAtt))
 				return cinder.ResultRequeue, fmt.Errorf("%w: %s", ErrNetworkAttachmentNotFound, netAtt)


### PR DESCRIPTION
Use consistent condition severity across repeated patterns found in our operators, and otherwise use an appropriate severity for conditions unique to each operator.

Jira: https://issues.redhat.com/browse/OSPRH-20095

Co-authored-by: Claude (Anthropic) claude@anthropic.com