### PR TITLE
Refactor: Make Cinder WSGI path conditional

### DIFF
--- a/templates/cinder/config/10-cinder_wsgi.conf
+++ b/templates/cinder/config/10-cinder_wsgi.conf
@@ -3,16 +3,18 @@
 <VirtualHost *:8776>
   ServerName {{ $vhost.ServerName }}
 
-  ## Vhost docroot
-  DocumentRoot "/var/www/cgi-bin/cinder"
+  ## Set DocumentRoot and Directory permissions only if the path exists
+  <If "-d '/var/www/cgi-bin/cinder'">
+    ## Vhost docroot
+    DocumentRoot "/var/www/cgi-bin/cinder"
 
-  ## Directories, there should at least be a declaration for /var/www/cgi-bin/cinder
-
-  <Directory "/var/www/cgi-bin/cinder">
-    Options -Indexes +FollowSymLinks +MultiViews
-    AllowOverride None
-    Require all granted
-  </Directory>
+    ## Directories, there should at least be a declaration for /var/www/cgi-bin/cinder
+    <Directory "/var/www/cgi-bin/cinder">
+      Options -Indexes +FollowSymLinks +MultiViews
+      AllowOverride None
+      Require all granted
+    </Directory>
+  </If>
 
   Timeout {{ $.TimeOut }}
 
@@ -34,7 +36,17 @@
   WSGIApplicationGroup %{GLOBAL}
   WSGIDaemonProcess {{ $endpt }} display-name={{ $endpt }} group=cinder processes=4 threads=1 user=cinder
   WSGIProcessGroup {{ $endpt }}
-  WSGIScriptAlias / "/var/www/cgi-bin/cinder/cinder-wsgi"
+  ## Conditionally set the WSGIScriptAlias based on file existence
+  <If "-f '/usr/lib/python3.12/site-packages/cinder/wsgi/api.py'">
+    WSGIScriptAlias / "/usr/lib/python3.12/site-packages/cinder/wsgi/api.py"
+  </If>
+  <ElseIf "-f '/usr/lib/python3.9/site-packages/cinder/wsgi/api.py'">
+    WSGIScriptAlias / "/usr/lib/python3.9/site-packages/cinder/wsgi/api.py"
+  </ElseIf>
+  <Else>
+    ## Fallback to the original path if neither python version is found
+    WSGIScriptAlias / "/var/www/cgi-bin/cinder/cinder-wsgi"
+  </Else>
   WSGIPassAuthorization On
 </VirtualHost>
 {{ end }}


### PR DESCRIPTION
https://review.opendev.org/c/openstack/cinder/+/960831 Remove pbr's wsgi_scripts from setup.cfg and recommends to use should instead reference the Python module path for this service, cinder.wsgi.api.

Since the cinder.wsgi.api path might be different for older release that's why we want to handle the path on operator side and point the path to python module directly.

Closes: [OSPCIX-1052](https://issues.redhat.com//browse/OSPCIX-1052)