### PR TITLE
Modernize Go code with latest style conventions

### DIFF
--- a/controllers/cinder_common.go
+++ b/controllers/cinder_common.go
@@ -48,7 +48,7 @@ var (
 
 type conditionUpdater interface {
 	Set(c *condition.Condition)
-	MarkTrue(t condition.Type, messageFormat string, messageArgs ...interface{})
+	MarkTrue(t condition.Type, messageFormat string, messageArgs ...any)
 }
 
 type topologyHandler interface {

--- a/controllers/cinder_controller.go
+++ b/controllers/cinder_controller.go
@@ -1019,7 +1019,7 @@ func (r *CinderReconciler) generateServiceConfigs(
 	databaseAccount := db.GetAccount()
 	dbSecret := db.GetSecret()
 
-	templateParameters := make(map[string]interface{})
+	templateParameters := make(map[string]any)
 	templateParameters["ServiceUser"] = instance.Spec.ServiceUser
 	templateParameters["ServicePassword"] = string(ospSecret.Data[instance.Spec.PasswordSelectors.Service])
 	templateParameters["KeystoneInternalURL"] = keystoneInternalURL
@@ -1043,9 +1043,9 @@ func (r *CinderReconciler) generateServiceConfigs(
 	}
 
 	// create httpd  vhost template parameters
-	httpdVhostConfig := map[string]interface{}{}
+	httpdVhostConfig := map[string]any{}
 	for _, endpt := range []service.Endpoint{service.EndpointInternal, service.EndpointPublic} {
-		endptConfig := map[string]interface{}{}
+		endptConfig := map[string]any{}
 		endptConfig["ServerName"] = fmt.Sprintf("%s-%s.%s.svc", cinder.ServiceName, endpt.String(), instance.Namespace)
 		endptConfig["TLS"] = false // default TLS to false, and set it bellow to true if enabled
 		if instance.Spec.CinderAPI.TLS.API.Enabled(endpt) {

--- a/controllers/cinderapi_controller.go
+++ b/controllers/cinderapi_controller.go
@@ -1082,7 +1082,7 @@ func (r *CinderAPIReconciler) generateServiceConfigs(
 	}
 	customData[cinder.CustomServiceConfigSecretsFileName] = customSecrets
 
-	templateParameters := map[string]interface{}{
+	templateParameters := map[string]any{
 		"LogFile": cinderapi.LogFile,
 	}
 

--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -46,14 +46,14 @@ func CreateCinderMessageBusSecret(namespace string, name string) *corev1.Secret 
 	s := th.CreateSecret(
 		types.NamespacedName{Namespace: namespace, Name: name},
 		map[string][]byte{
-			"transport_url": []byte(fmt.Sprintf("rabbit://%s/fake", name)),
+			"transport_url": fmt.Appendf(nil, "rabbit://%s/fake", name),
 		},
 	)
 	logger.Info("Secret created", "name", name)
 	return s
 }
 
-func CreateUnstructured(rawObj map[string]interface{}) *unstructured.Unstructured {
+func CreateUnstructured(rawObj map[string]any) *unstructured.Unstructured {
 	logger.Info("Creating", "raw", rawObj)
 	unstructuredObj := &unstructured.Unstructured{Object: rawObj}
 	_, err := controllerutil.CreateOrPatch(
@@ -62,15 +62,15 @@ func CreateUnstructured(rawObj map[string]interface{}) *unstructured.Unstructure
 	return unstructuredObj
 }
 
-func GetCinderEmptySpec() map[string]interface{} {
-	return map[string]interface{}{
+func GetCinderEmptySpec() map[string]any {
+	return map[string]any{
 		"databaseInstance": "openstack",
 		"secret":           SecretName,
 	}
 }
 
-func GetDefaultCinderSpec() map[string]interface{} {
-	return map[string]interface{}{
+func GetDefaultCinderSpec() map[string]any {
+	return map[string]any{
 		"databaseInstance": "openstack",
 		"secret":           SecretName,
 		"cinderAPI":        GetDefaultCinderAPISpec(),
@@ -79,8 +79,8 @@ func GetDefaultCinderSpec() map[string]interface{} {
 	}
 }
 
-func GetTLSCinderSpec() map[string]interface{} {
-	return map[string]interface{}{
+func GetTLSCinderSpec() map[string]any {
+	return map[string]any{
 		"databaseInstance": "openstack",
 		"secret":           SecretName,
 		"cinderAPI":        GetTLSCinderAPISpec(),
@@ -89,8 +89,8 @@ func GetTLSCinderSpec() map[string]interface{} {
 	}
 }
 
-func GetDefaultCinderAPISpec() map[string]interface{} {
-	return map[string]interface{}{
+func GetDefaultCinderAPISpec() map[string]any {
+	return map[string]any{
 		"secret":             SecretName,
 		"replicas":           1,
 		"containerImage":     cinderTest.ContainerImage,
@@ -100,15 +100,15 @@ func GetDefaultCinderAPISpec() map[string]interface{} {
 	}
 }
 
-func GetTLSCinderAPISpec() map[string]interface{} {
+func GetTLSCinderAPISpec() map[string]any {
 	spec := GetDefaultCinderAPISpec()
-	maps.Copy(spec, map[string]interface{}{
-		"tls": map[string]interface{}{
-			"api": map[string]interface{}{
-				"internal": map[string]interface{}{
+	maps.Copy(spec, map[string]any{
+		"tls": map[string]any{
+			"api": map[string]any{
+				"internal": map[string]any{
 					"secretName": InternalCertSecretName,
 				},
-				"public": map[string]interface{}{
+				"public": map[string]any{
 					"secretName": PublicCertSecretName,
 				},
 			},
@@ -119,8 +119,8 @@ func GetTLSCinderAPISpec() map[string]interface{} {
 	return spec
 }
 
-func GetDefaultCinderSchedulerSpec() map[string]interface{} {
-	return map[string]interface{}{
+func GetDefaultCinderSchedulerSpec() map[string]any {
+	return map[string]any{
 		"secret":             SecretName,
 		"replicas":           1,
 		"containerImage":     cinderTest.ContainerImage,
@@ -130,8 +130,8 @@ func GetDefaultCinderSchedulerSpec() map[string]interface{} {
 	}
 }
 
-func GetDefaultCinderVolumeSpec() map[string]interface{} {
-	return map[string]interface{}{
+func GetDefaultCinderVolumeSpec() map[string]any {
+	return map[string]any{
 		"secret":             SecretName,
 		"replicas":           1,
 		"containerImage":     cinderTest.ContainerImage,
@@ -149,12 +149,12 @@ func GetCinder(name types.NamespacedName) *cinderv1.Cinder {
 	return instance
 }
 
-func CreateCinder(name types.NamespacedName, spec map[string]interface{}) client.Object {
+func CreateCinder(name types.NamespacedName, spec map[string]any) client.Object {
 
-	raw := map[string]interface{}{
+	raw := map[string]any{
 		"apiVersion": "cinder.openstack.org/v1beta1",
 		"kind":       "Cinder",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name.Name,
 			"namespace": name.Namespace,
 		},
@@ -168,11 +168,11 @@ func CinderConditionGetter(name types.NamespacedName) condition.Conditions {
 	return instance.Status.Conditions
 }
 
-func CreateCinderAPI(name types.NamespacedName, spec map[string]interface{}) client.Object {
-	raw := map[string]interface{}{
+func CreateCinderAPI(name types.NamespacedName, spec map[string]any) client.Object {
+	raw := map[string]any{
 		"apiVersion": "cinder.openstack.org/v1beta1",
 		"kind":       "CinderAPI",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name.Name,
 			"namespace": name.Namespace,
 		},
@@ -181,11 +181,11 @@ func CreateCinderAPI(name types.NamespacedName, spec map[string]interface{}) cli
 	return CreateUnstructured(raw)
 }
 
-func CreateCinderScheduler(name types.NamespacedName, spec map[string]interface{}) client.Object {
-	raw := map[string]interface{}{
+func CreateCinderScheduler(name types.NamespacedName, spec map[string]any) client.Object {
+	raw := map[string]any{
 		"apiVersion": "cinder.openstack.org/v1beta1",
 		"kind":       "CinderScheduler",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name.Name,
 			"namespace": name.Namespace,
 		},
@@ -194,11 +194,11 @@ func CreateCinderScheduler(name types.NamespacedName, spec map[string]interface{
 	return CreateUnstructured(raw)
 }
 
-func CreateCinderVolume(name types.NamespacedName, spec map[string]interface{}) client.Object {
-	raw := map[string]interface{}{
+func CreateCinderVolume(name types.NamespacedName, spec map[string]any) client.Object {
+	raw := map[string]any{
 		"apiVersion": "cinder.openstack.org/v1beta1",
 		"kind":       "CinderVolume",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name.Name,
 			"namespace": name.Namespace,
 		},
@@ -323,26 +323,26 @@ func CinderVolumeNotExists(name types.NamespacedName) {
 
 // GetExtraMounts - Utility function that simulates extraMounts pointing
 // to a Ceph secret
-func GetExtraMounts() []map[string]interface{} {
-	return []map[string]interface{}{
+func GetExtraMounts() []map[string]any {
+	return []map[string]any{
 		{
 			"name":   cinderTest.Instance.Name,
 			"region": "az0",
-			"extraVol": []map[string]interface{}{
+			"extraVol": []map[string]any{
 				{
 					"extraVolType": CinderCephExtraMountsSecretName,
 					"propagation": []string{
 						"CinderVolume",
 					},
-					"volumes": []map[string]interface{}{
+					"volumes": []map[string]any{
 						{
 							"name": CinderCephExtraMountsSecretName,
-							"secret": map[string]interface{}{
+							"secret": map[string]any{
 								"secretName": CinderCephExtraMountsSecretName,
 							},
 						},
 					},
-					"mounts": []map[string]interface{}{
+					"mounts": []map[string]any{
 						{
 							"name":      CinderCephExtraMountsSecretName,
 							"mountPath": CinderCephExtraMountsPath,
@@ -361,16 +361,16 @@ func GetExtraMounts() []map[string]interface{} {
 // test Service components. It returns both the user input representation
 // in the form of map[string]string, and the Golang expected representation
 // used in the test asserts.
-func GetSampleTopologySpec(label string) (map[string]interface{}, []corev1.TopologySpreadConstraint) {
+func GetSampleTopologySpec(label string) (map[string]any, []corev1.TopologySpreadConstraint) {
 	// Build the topology Spec
-	topologySpec := map[string]interface{}{
-		"topologySpreadConstraints": []map[string]interface{}{
+	topologySpec := map[string]any{
+		"topologySpreadConstraints": []map[string]any{
 			{
 				"maxSkew":           1,
 				"topologyKey":       corev1.LabelHostname,
 				"whenUnsatisfiable": "ScheduleAnyway",
-				"labelSelector": map[string]interface{}{
-					"matchLabels": map[string]interface{}{
+				"labelSelector": map[string]any{
+					"matchLabels": map[string]any{
 						"component": label,
 					},
 				},

--- a/test/functional/cinder_controller_test.go
+++ b/test/functional/cinder_controller_test.go
@@ -395,8 +395,8 @@ var _ = Describe("Cinder controller", func() {
 		BeforeEach(func() {
 			nad := th.CreateNetworkAttachmentDefinition(cinderTest.InternalAPINAD)
 			DeferCleanup(th.DeleteInstance, nad)
-			serviceOverride := map[string]interface{}{}
-			serviceOverride["internal"] = map[string]interface{}{
+			serviceOverride := map[string]any{}
+			serviceOverride["internal"] = map[string]any{
 				"metadata": map[string]map[string]string{
 					"annotations": {
 						"metallb.universe.tf/address-pool":     "osp-internalapi",
@@ -408,28 +408,28 @@ var _ = Describe("Cinder controller", func() {
 						"service":  "nova",
 					},
 				},
-				"spec": map[string]interface{}{
+				"spec": map[string]any{
 					"type": "LoadBalancer",
 				},
 			}
 
-			rawSpec := map[string]interface{}{
+			rawSpec := map[string]any{
 				"secret":              SecretName,
 				"databaseInstance":    "openstack",
 				"rabbitMqClusterName": "rabbitmq",
-				"cinderAPI": map[string]interface{}{
+				"cinderAPI": map[string]any{
 					"containerImage":     cinderv1.CinderAPIContainerImage,
 					"networkAttachments": []string{"internalapi"},
-					"override": map[string]interface{}{
+					"override": map[string]any{
 						"service": serviceOverride,
 					},
 				},
-				"cinderScheduler": map[string]interface{}{
+				"cinderScheduler": map[string]any{
 					"containerImage":     cinderv1.CinderSchedulerContainerImage,
 					"networkAttachments": []string{"internalapi"},
 				},
-				"cinderVolumes": map[string]interface{}{
-					"volume1": map[string]interface{}{
+				"cinderVolumes": map[string]any{
+					"volume1": map[string]any{
 						"containerImage":     cinderv1.CinderVolumeContainerImage,
 						"networkAttachments": []string{"internalapi"},
 					},
@@ -737,12 +737,12 @@ var _ = Describe("Cinder controller", func() {
 				Name:      cinderTest.CinderTopologies[1].Name,
 				Namespace: cinderTest.CinderTopologies[1].Namespace,
 			}
-			spec["topologyRef"] = map[string]interface{}{
+			spec["topologyRef"] = map[string]any{
 				"name": topologyRef.Name,
 			}
 			// Override topologyRef for cinderVolume subCR
-			spec["cinderVolumes"] = map[string]interface{}{
-				"volume1": map[string]interface{}{},
+			spec["cinderVolumes"] = map[string]any{
+				"volume1": map[string]any{},
 			}
 
 			DeferCleanup(th.DeleteInstance, CreateCinder(cinderTest.Instance, spec))
@@ -981,11 +981,11 @@ var _ = Describe("Cinder controller", func() {
 	When("A Cinder is created with nodeSelector", func() {
 		BeforeEach(func() {
 			spec := GetDefaultCinderSpec()
-			spec["nodeSelector"] = map[string]interface{}{
+			spec["nodeSelector"] = map[string]any{
 				"foo": "bar",
 			}
-			spec["cinderVolumes"] = map[string]interface{}{
-				"volume1": map[string]interface{}{
+			spec["cinderVolumes"] = map[string]any{
+				"volume1": map[string]any{
 					"containerImage": cinderv1.CinderVolumeContainerImage,
 				},
 			}
@@ -1178,19 +1178,19 @@ var _ = Describe("Cinder controller", func() {
 
 	When("Cinder CR instance is built with ExtraMounts", func() {
 		BeforeEach(func() {
-			rawSpec := map[string]interface{}{
+			rawSpec := map[string]any{
 				"secret":              SecretName,
 				"databaseInstance":    "openstack",
 				"rabbitMqClusterName": "rabbitmq",
 				"extraMounts":         GetExtraMounts(),
-				"cinderAPI": map[string]interface{}{
+				"cinderAPI": map[string]any{
 					"containerImage": cinderv1.CinderAPIContainerImage,
 				},
-				"cinderScheduler": map[string]interface{}{
+				"cinderScheduler": map[string]any{
 					"containerImage": cinderv1.CinderSchedulerContainerImage,
 				},
-				"cinderVolumes": map[string]interface{}{
-					"volume1": map[string]interface{}{
+				"cinderVolumes": map[string]any{
+					"volume1": map[string]any{
 						"containerImage": cinderv1.CinderVolumeContainerImage,
 					},
 				},
@@ -1242,19 +1242,19 @@ var _ = Describe("Cinder controller", func() {
 
 	When("Cinder instance has notifications enabled", func() {
 		BeforeEach(func() {
-			rawSpec := map[string]interface{}{
+			rawSpec := map[string]any{
 				"secret":                   SecretName,
 				"databaseInstance":         "openstack",
 				"rabbitMqClusterName":      "rabbitmq",
 				"notificationsBusInstance": "rabbitmq",
-				"cinderAPI": map[string]interface{}{
+				"cinderAPI": map[string]any{
 					"containerImage": cinderv1.CinderAPIContainerImage,
 				},
-				"cinderScheduler": map[string]interface{}{
+				"cinderScheduler": map[string]any{
 					"containerImage": cinderv1.CinderSchedulerContainerImage,
 				},
-				"cinderVolumes": map[string]interface{}{
-					"volume1": map[string]interface{}{
+				"cinderVolumes": map[string]any{
+					"volume1": map[string]any{
 						"containerImage": cinderv1.CinderVolumeContainerImage,
 					},
 				},
@@ -1588,18 +1588,18 @@ var _ = Describe("Cinder Webhook", func() {
 	It("rejects with wrong CinderAPI service override endpoint type", func() {
 		spec := GetDefaultCinderSpec()
 		apiSpec := GetDefaultCinderAPISpec()
-		apiSpec["override"] = map[string]interface{}{
-			"service": map[string]interface{}{
-				"internal": map[string]interface{}{},
-				"wrooong":  map[string]interface{}{},
+		apiSpec["override"] = map[string]any{
+			"service": map[string]any{
+				"internal": map[string]any{},
+				"wrooong":  map[string]any{},
 			},
 		}
 		spec["cinderAPI"] = apiSpec
 
-		raw := map[string]interface{}{
+		raw := map[string]any{
 			"apiVersion": "cinder.openstack.org/v1beta1",
 			"kind":       "Cinder",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      cinderTest.Instance.Name,
 				"namespace": cinderTest.Instance.Namespace,
 			},
@@ -1619,17 +1619,17 @@ var _ = Describe("Cinder Webhook", func() {
 
 	It("webhooks reject the request - cinderVolume key too long", func() {
 		spec := GetDefaultCinderSpec()
-		raw := map[string]interface{}{
+		raw := map[string]any{
 			"apiVersion": "cinder.openstack.org/v1beta1",
 			"kind":       "Cinder",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      cinderTest.Instance.Name,
 				"namespace": cinderTest.Instance.Namespace,
 			},
 			"spec": spec,
 		}
 
-		volumeList := map[string]interface{}{
+		volumeList := map[string]any{
 			"foo-1234567890-1234567890-1234567890-1234567890-1234567890": GetDefaultCinderVolumeSpec(),
 		}
 		spec["cinderVolumes"] = volumeList
@@ -1649,17 +1649,17 @@ var _ = Describe("Cinder Webhook", func() {
 
 	It("webhooks reject the request - cinderVolume wrong key/name", func() {
 		spec := GetDefaultCinderSpec()
-		raw := map[string]interface{}{
+		raw := map[string]any{
 			"apiVersion": "cinder.openstack.org/v1beta1",
 			"kind":       "Cinder",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      cinderTest.Instance.Name,
 				"namespace": cinderTest.Instance.Namespace,
 			},
 			"spec": spec,
 		}
 
-		volumeList := map[string]interface{}{
+		volumeList := map[string]any{
 			"foo_bar": GetDefaultCinderVolumeSpec(),
 		}
 		spec["cinderVolumes"] = volumeList
@@ -1686,8 +1686,8 @@ var _ = Describe("Cinder Webhook", func() {
 			spec := GetDefaultCinderSpec()
 			// API and Scheduler
 			if component != "top-level" && component != "volume0" {
-				spec[component] = map[string]interface{}{
-					"topologyRef": map[string]interface{}{
+				spec[component] = map[string]any{
+					"topologyRef": map[string]any{
 						"name":      "bar",
 						"namespace": "foo",
 					},
@@ -1695,9 +1695,9 @@ var _ = Describe("Cinder Webhook", func() {
 			}
 			// cinderVolumes volume0
 			if component == "volume0" {
-				volumeList := map[string]interface{}{
-					"volume0": map[string]interface{}{
-						"topologyRef": map[string]interface{}{
+				volumeList := map[string]any{
+					"volume0": map[string]any{
+						"topologyRef": map[string]any{
 							"name":      "foo",
 							"namespace": "bar",
 						},
@@ -1706,16 +1706,16 @@ var _ = Describe("Cinder Webhook", func() {
 				spec["cinderVolumes"] = volumeList
 				// top-level topologyRef
 			} else {
-				spec["topologyRef"] = map[string]interface{}{
+				spec["topologyRef"] = map[string]any{
 					"name":      "bar",
 					"namespace": "foo",
 				}
 			}
 			// Build the cinder CR
-			raw := map[string]interface{}{
+			raw := map[string]any{
 				"apiVersion": "cinder.openstack.org/v1beta1",
 				"kind":       "Cinder",
-				"metadata": map[string]interface{}{
+				"metadata": map[string]any{
 					"name":      cinderTest.Instance.Name,
 					"namespace": cinderTest.Instance.Namespace,
 				},


### PR DESCRIPTION
Applied automated modernization using gopls modernize tool to update:
- Replace interface{} with any type alias (Go 1.18+)
- Update range loops to use idiomatic range syntax
- Replace fmt.Sprintf with fmt.Appendf where appropriate

These changes improve code readability and align with current Go best practices.

Co-Authored-By: Claude [noreply@anthropic.com](mailto:noreply@anthropic.com)