### PR TITLE
Ensure deterministic map iteration to stabilize reconciliation

### DIFF
--- a/internal/controller/cinder_controller.go
+++ b/internal/controller/cinder_controller.go
@@ -19,6 +19,8 @@ package controller
 import (
 	"context"
 	"fmt"
+	"maps"
+	"slices"
 	"time"
 
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
@@ -901,7 +903,8 @@ func (r *CinderReconciler) reconcileNormal(ctx context.Context, instance *cinder
 	if instance.Spec.CinderBackups != nil {
 		var bckCondition *condition.Condition
 		waitingBkpGenerationMatch := false
-		for name, backup := range *instance.Spec.CinderBackups {
+		for _, name := range slices.Sorted(maps.Keys(*instance.Spec.CinderBackups)) {
+			backup := (*instance.Spec.CinderBackups)[name]
 			crName := fmt.Sprintf("%s-backup-%s", instance.Name, name)
 			if *backup.Replicas > 0 {
 				cinderBackup, op, err := r.backupDeploymentCreateOrUpdate(ctx, instance, crName, &backup)
@@ -956,7 +959,8 @@ func (r *CinderReconciler) reconcileNormal(ctx context.Context, instance *cinder
 	// deploy cinder-volumes
 	var volumeCondition *condition.Condition
 	waitingGenerationMatch := false
-	for name, volume := range instance.Spec.CinderVolumes {
+	for _, name := range slices.Sorted(maps.Keys(instance.Spec.CinderVolumes)) {
+		volume := instance.Spec.CinderVolumes[name]
 		cinderVolume, op, err := r.volumeDeploymentCreateOrUpdate(ctx, instance, name, volume)
 		if err != nil {
 			instance.Status.Conditions.Set(condition.FalseCondition(

--- a/internal/controller/cinderapi_controller.go
+++ b/internal/controller/cinderapi_controller.go
@@ -19,6 +19,8 @@ package controller
 import (
 	"context"
 	"fmt"
+	"maps"
+	"slices"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -478,7 +480,8 @@ func (r *CinderAPIReconciler) reconcileInit(
 
 	apiEndpointsV3 := make(map[string]string)
 
-	for endpointType, data := range cinderEndpoints {
+	for _, endpointType := range slices.Sorted(maps.Keys(cinderEndpoints)) {
+		data := cinderEndpoints[endpointType]
 		endpointTypeStr := string(endpointType)
 		endpointName := cinder.ServiceName + "-" + endpointTypeStr
 		svcOverride := instance.Spec.Override.Service[endpointType]
@@ -1083,8 +1086,8 @@ func (r *CinderAPIReconciler) generateServiceConfigs(
 		if err != nil {
 			return err
 		}
-		for _, data := range secret.Data {
-			customSecrets += string(data) + "\n"
+		for _, key := range slices.Sorted(maps.Keys(secret.Data)) {
+			customSecrets += string(secret.Data[key]) + "\n"
 		}
 	}
 	customData[cinder.CustomServiceConfigSecretsFileName] = customSecrets

--- a/internal/controller/cinderbackup_controller.go
+++ b/internal/controller/cinderbackup_controller.go
@@ -19,6 +19,8 @@ package controller
 import (
 	"context"
 	"fmt"
+	"maps"
+	"slices"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -729,8 +731,8 @@ func (r *CinderBackupReconciler) generateServiceConfigs(
 		if err != nil {
 			return err
 		}
-		for _, data := range secret.Data {
-			customSecrets += string(data) + "\n"
+		for _, key := range slices.Sorted(maps.Keys(secret.Data)) {
+			customSecrets += string(secret.Data[key]) + "\n"
 		}
 	}
 	customData[cinder.CustomServiceConfigSecretsFileName] = customSecrets

--- a/internal/controller/cinderscheduler_controller.go
+++ b/internal/controller/cinderscheduler_controller.go
@@ -19,6 +19,8 @@ package controller
 import (
 	"context"
 	"fmt"
+	"maps"
+	"slices"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -727,8 +729,8 @@ func (r *CinderSchedulerReconciler) generateServiceConfigs(
 		if err != nil {
 			return err
 		}
-		for _, data := range secret.Data {
-			customSecrets += string(data) + "\n"
+		for _, key := range slices.Sorted(maps.Keys(secret.Data)) {
+			customSecrets += string(secret.Data[key]) + "\n"
 		}
 	}
 	customData[cinder.CustomServiceConfigSecretsFileName] = customSecrets

--- a/internal/controller/cindervolume_controller.go
+++ b/internal/controller/cindervolume_controller.go
@@ -19,6 +19,8 @@ package controller
 import (
 	"context"
 	"fmt"
+	"maps"
+	"slices"
 	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -732,8 +734,8 @@ func (r *CinderVolumeReconciler) generateServiceConfigs(
 		if err != nil {
 			return usesLVM, err
 		}
-		for _, data := range secret.Data {
-			customSecrets += string(data) + "\n"
+		for _, key := range slices.Sorted(maps.Keys(secret.Data)) {
+			customSecrets += string(secret.Data[key]) + "\n"
 		}
 	}
 	customData[cinder.CustomServiceConfigSecretsFileName] = customSecrets


### PR DESCRIPTION
Replace non-deterministic map range loops with sorted iteration using `slices.Sorted(maps.Keys(...))` to prevent unnecessary reconciliations caused by unstable ordering of condition messages, endpoints, and secret data concatenation.

Closes: [OSPRH-28402](https://redhat.atlassian.net/browse/OSPRH-28402)