### PR TITLE
Add support for cinder-manage online data migrations

### DIFF
--- a/api/v1beta1/cinder_types.go
+++ b/api/v1beta1/cinder_types.go
@@ -34,6 +34,9 @@ const (
 	// DbSyncHash hash
 	DbSyncHash = "dbsync"
 
+	// OnlineDataMigrationHash hash
+	OnlineDataMigrationHash = "onlinedatamigration"
+
 	// DeploymentHash hash used to detect changes
 	DeploymentHash = "deployment"
 

--- a/api/v1beta1/conditions.go
+++ b/api/v1beta1/conditions.go
@@ -32,6 +32,9 @@ const (
 
 	// CinderVolumeReadyCondition Status=True condition which indicates if the CinderVolume is configured and operational
 	CinderVolumeReadyCondition condition.Type = "CinderVolumeReady"
+
+	// OnlineDataMigrationReadyCondition Status=True condition which indicates if the online data migrations have completed
+	OnlineDataMigrationReadyCondition condition.Type = "OnlineDataMigrationReady"
 )
 
 // Cinder Reasons used by API objects.
@@ -77,4 +80,19 @@ const (
 
 	// CinderVolumeReadyRunningMessage
 	CinderVolumeReadyRunningMessage = "CinderVolume deployments in progress"
+
+	//
+	// OnlineDataMigrationReady condition messages
+	//
+	// OnlineDataMigrationReadyInitMessage
+	OnlineDataMigrationReadyInitMessage = "OnlineDataMigration not started"
+
+	// OnlineDataMigrationReadyMessage
+	OnlineDataMigrationReadyMessage = "OnlineDataMigration completed"
+
+	// OnlineDataMigrationReadyRunningMessage
+	OnlineDataMigrationReadyRunningMessage = "OnlineDataMigration in progress"
+
+	// OnlineDataMigrationReadyErrorMessage
+	OnlineDataMigrationReadyErrorMessage = "OnlineDataMigration error occurred %s"
 )

--- a/internal/cinder/dbsync.go
+++ b/internal/cinder/dbsync.go
@@ -18,20 +18,53 @@ const (
 	//       conditionally (only for adoption) and do the restart cycle of
 	//       services as described in the upstream rolling upgrades process.
 	DBSyncCommand = "/usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start"
+	
+	// OnlineDataMigrationsCommand - for running online data migrations during upgrades
+	OnlineDataMigrationsCommand = "/usr/bin/cinder-manage --config-dir /etc/cinder/cinder.conf.d db online_data_migrations"
 )
 
-// DbSyncJob func
-func DbSyncJob(instance *cinderv1beta1.Cinder, labels map[string]string, annotations map[string]string) *batchv1.Job {
+// CinderManageJobType defines the type of cinder-manage command to run
+type CinderManageJobType string
+
+const (
+	// DbSyncJobType for database synchronization
+	DbSyncJobType CinderManageJobType = "db-sync"
+	// OnlineDataMigrationsJobType for online data migrations
+	OnlineDataMigrationsJobType CinderManageJobType = "online-data-migrations"
+)
+
+// CinderManageJob creates a job for running various cinder-manage commands
+func CinderManageJob(instance *cinderv1beta1.Cinder, jobType CinderManageJobType, labels map[string]string, annotations map[string]string) *batchv1.Job {
 	var config0644AccessMode int32 = 0644
 
-	// Unlike the individual cinder services, the DbSyncJob doesn't need a
+	// Determine job name suffix and command based on job type
+	var jobNameSuffix string
+	var command string
+	var useKollaConfig bool
+	
+	switch jobType {
+	case DbSyncJobType:
+		jobNameSuffix = "db-sync"
+		command = DBSyncCommand
+		useKollaConfig = true
+	case OnlineDataMigrationsJobType:
+		jobNameSuffix = "online-data-migrations"
+		command = OnlineDataMigrationsCommand
+		useKollaConfig = false
+	default:
+		jobNameSuffix = "db-sync"
+		command = DBSyncCommand
+		useKollaConfig = true
+	}
+
+	// Unlike the individual cinder services, cinder-manage jobs don't need a
 	// secret that contains all of the config snippets required by every
 	// service, The two snippet files that it does need (DefaultsConfigFileName
 	// and CustomConfigFileName) can be extracted from the top-level cinder
 	// config-data secret.
-	dbSyncVolume := []corev1.Volume{
+	jobVolume := []corev1.Volume{
 		{
-			Name: "db-sync-config-data",
+			Name: "config-data",
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
 					DefaultMode: &config0644AccessMode,
@@ -51,38 +84,46 @@ func DbSyncJob(instance *cinderv1beta1.Cinder, labels map[string]string, annotat
 		},
 	}
 
-	dbSyncMounts := []corev1.VolumeMount{
+	jobMounts := []corev1.VolumeMount{
 		{
-			Name:      "db-sync-config-data",
+			Name:      "config-data",
 			MountPath: "/etc/cinder/cinder.conf.d",
 			ReadOnly:  true,
 		},
-		{
+	}
+
+	// Add kolla config mount only for db-sync jobs
+	if useKollaConfig {
+		jobMounts = append(jobMounts, corev1.VolumeMount{
 			Name:      "config-data",
 			MountPath: "/var/lib/kolla/config_files/config.json",
 			SubPath:   "db-sync-config.json",
 			ReadOnly:  true,
-		},
+		})
 	}
 
 	// add CA cert if defined
 	if instance.Spec.CinderAPI.TLS.CaBundleSecretName != "" {
-		dbSyncVolume = append(dbSyncVolume, instance.Spec.CinderAPI.TLS.CreateVolume())
-		dbSyncMounts = append(dbSyncMounts, instance.Spec.CinderAPI.TLS.CreateVolumeMounts(nil)...)
+		jobVolume = append(jobVolume, instance.Spec.CinderAPI.TLS.CreateVolume())
+		jobMounts = append(jobMounts, instance.Spec.CinderAPI.TLS.CreateVolumeMounts(nil)...)
 	}
 
-	dbSyncExtraMounts := []cinderv1beta1.CinderExtraVolMounts{}
+	jobExtraMounts := []cinderv1beta1.CinderExtraVolMounts{}
 
-	args := []string{"-c", DBSyncCommand}
+	args := []string{"-c", command}
 
 	runAsUser := int64(0)
 	envVars := map[string]env.Setter{}
-	envVars["KOLLA_CONFIG_STRATEGY"] = env.SetValue("COPY_ALWAYS")
-	envVars["KOLLA_BOOTSTRAP"] = env.SetValue("TRUE")
+	
+	// Set environment variables based on job type
+	if useKollaConfig {
+		envVars["KOLLA_CONFIG_STRATEGY"] = env.SetValue("COPY_ALWAYS")
+		envVars["KOLLA_BOOTSTRAP"] = env.SetValue("TRUE")
+	}
 
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      instance.Name + "-db-sync",
+			Name:      instance.Name + "-" + jobNameSuffix,
 			Namespace: instance.Namespace,
 			Labels:    labels,
 		},
@@ -96,7 +137,7 @@ func DbSyncJob(instance *cinderv1beta1.Cinder, labels map[string]string, annotat
 					ServiceAccountName: instance.RbacResourceName(),
 					Containers: []corev1.Container{
 						{
-							Name: instance.Name + "-db-sync",
+							Name: instance.Name + "-" + jobNameSuffix,
 							Command: []string{
 								"/bin/bash",
 							},
@@ -106,10 +147,10 @@ func DbSyncJob(instance *cinderv1beta1.Cinder, labels map[string]string, annotat
 								RunAsUser: &runAsUser,
 							},
 							Env:          env.MergeEnvs([]corev1.EnvVar{}, envVars),
-							VolumeMounts: append(GetVolumeMounts(false, dbSyncExtraMounts, DbsyncPropagation), dbSyncMounts...),
+							VolumeMounts: append(GetVolumeMounts(false, jobExtraMounts, DbsyncPropagation), jobMounts...),
 						},
 					},
-					Volumes: append(GetVolumes(instance.Name, false, dbSyncExtraMounts, DbsyncPropagation), dbSyncVolume...),
+					Volumes: append(GetVolumes(instance.Name, false, jobExtraMounts, DbsyncPropagation), jobVolume...),
 				},
 			},
 		},
@@ -120,4 +161,14 @@ func DbSyncJob(instance *cinderv1beta1.Cinder, labels map[string]string, annotat
 	}
 
 	return job
+}
+
+// DbSyncJob func - backward compatible wrapper for database sync
+func DbSyncJob(instance *cinderv1beta1.Cinder, labels map[string]string, annotations map[string]string) *batchv1.Job {
+	return CinderManageJob(instance, DbSyncJobType, labels, annotations)
+}
+
+// OnlineDataMigrationsJob creates a job for running cinder-manage db online_data_migrations
+func OnlineDataMigrationsJob(instance *cinderv1beta1.Cinder, labels map[string]string, annotations map[string]string) *batchv1.Job {
+	return CinderManageJob(instance, OnlineDataMigrationsJobType, labels, annotations)
 }

--- a/internal/cinder/job.go
+++ b/internal/cinder/job.go
@@ -8,6 +8,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// ManageJobType defines the type of cinder-manage command to run
+type ManageJobType string
+
 const (
 	// DBSyncCommand -
 	// TODO: Once we work on update/upgrades revisit the command in the
@@ -17,44 +20,33 @@ const (
 	//       If we are doing rolling upgrades we'll need to use the flag
 	//       conditionally (only for adoption) and do the restart cycle of
 	//       services as described in the upstream rolling upgrades process.
-	DBSyncCommand = "/usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start"
-	
+	DBSyncCommand = "/usr/bin/cinder-manage --config-dir /etc/cinder/cinder.conf.d db sync --bump-versions"
 	// OnlineDataMigrationsCommand - for running online data migrations during upgrades
 	OnlineDataMigrationsCommand = "/usr/bin/cinder-manage --config-dir /etc/cinder/cinder.conf.d db online_data_migrations"
-)
-
-// CinderManageJobType defines the type of cinder-manage command to run
-type CinderManageJobType string
-
-const (
 	// DbSyncJobType for database synchronization
-	DbSyncJobType CinderManageJobType = "db-sync"
+	DbSyncJobType ManageJobType = "db-sync"
 	// OnlineDataMigrationsJobType for online data migrations
-	OnlineDataMigrationsJobType CinderManageJobType = "online-data-migrations"
+	OnlineDataMigrationsJobType ManageJobType = "online-data-migrations"
 )
 
-// CinderManageJob creates a job for running various cinder-manage commands
-func CinderManageJob(instance *cinderv1beta1.Cinder, jobType CinderManageJobType, labels map[string]string, annotations map[string]string) *batchv1.Job {
+// ManageJob - creates a job for running various cinder-manage commands
+func ManageJob(instance *cinderv1beta1.Cinder, jobType ManageJobType, labels map[string]string, annotations map[string]string) *batchv1.Job {
 	var config0644AccessMode int32 = 0644
 
 	// Determine job name suffix and command based on job type
 	var jobNameSuffix string
 	var command string
-	var useKollaConfig bool
-	
+
 	switch jobType {
 	case DbSyncJobType:
 		jobNameSuffix = "db-sync"
 		command = DBSyncCommand
-		useKollaConfig = true
 	case OnlineDataMigrationsJobType:
 		jobNameSuffix = "online-data-migrations"
 		command = OnlineDataMigrationsCommand
-		useKollaConfig = false
 	default:
 		jobNameSuffix = "db-sync"
 		command = DBSyncCommand
-		useKollaConfig = true
 	}
 
 	// Unlike the individual cinder services, cinder-manage jobs don't need a
@@ -92,34 +84,16 @@ func CinderManageJob(instance *cinderv1beta1.Cinder, jobType CinderManageJobType
 		},
 	}
 
-	// Add kolla config mount only for db-sync jobs
-	if useKollaConfig {
-		jobMounts = append(jobMounts, corev1.VolumeMount{
-			Name:      "config-data",
-			MountPath: "/var/lib/kolla/config_files/config.json",
-			SubPath:   "db-sync-config.json",
-			ReadOnly:  true,
-		})
-	}
-
 	// add CA cert if defined
 	if instance.Spec.CinderAPI.TLS.CaBundleSecretName != "" {
 		jobVolume = append(jobVolume, instance.Spec.CinderAPI.TLS.CreateVolume())
 		jobMounts = append(jobMounts, instance.Spec.CinderAPI.TLS.CreateVolumeMounts(nil)...)
 	}
 
-	jobExtraMounts := []cinderv1beta1.CinderExtraVolMounts{}
-
 	args := []string{"-c", command}
 
 	runAsUser := int64(0)
 	envVars := map[string]env.Setter{}
-	
-	// Set environment variables based on job type
-	if useKollaConfig {
-		envVars["KOLLA_CONFIG_STRATEGY"] = env.SetValue("COPY_ALWAYS")
-		envVars["KOLLA_BOOTSTRAP"] = env.SetValue("TRUE")
-	}
 
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
@@ -147,10 +121,10 @@ func CinderManageJob(instance *cinderv1beta1.Cinder, jobType CinderManageJobType
 								RunAsUser: &runAsUser,
 							},
 							Env:          env.MergeEnvs([]corev1.EnvVar{}, envVars),
-							VolumeMounts: append(GetVolumeMounts(false, jobExtraMounts, DbsyncPropagation), jobMounts...),
+							VolumeMounts: jobMounts,
 						},
 					},
-					Volumes: append(GetVolumes(instance.Name, false, jobExtraMounts, DbsyncPropagation), jobVolume...),
+					Volumes: jobVolume,
 				},
 			},
 		},
@@ -165,10 +139,10 @@ func CinderManageJob(instance *cinderv1beta1.Cinder, jobType CinderManageJobType
 
 // DbSyncJob func - backward compatible wrapper for database sync
 func DbSyncJob(instance *cinderv1beta1.Cinder, labels map[string]string, annotations map[string]string) *batchv1.Job {
-	return CinderManageJob(instance, DbSyncJobType, labels, annotations)
+	return ManageJob(instance, DbSyncJobType, labels, annotations)
 }
 
 // OnlineDataMigrationsJob creates a job for running cinder-manage db online_data_migrations
 func OnlineDataMigrationsJob(instance *cinderv1beta1.Cinder, labels map[string]string, annotations map[string]string) *batchv1.Job {
-	return CinderManageJob(instance, OnlineDataMigrationsJobType, labels, annotations)
+	return ManageJob(instance, OnlineDataMigrationsJobType, labels, annotations)
 }

--- a/internal/cinder/job.go
+++ b/internal/cinder/job.go
@@ -1,6 +1,7 @@
 package cinder
 
 import (
+	"fmt"
 	cinderv1beta1 "github.com/openstack-k8s-operators/cinder-operator/api/v1beta1"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/env"
 	batchv1 "k8s.io/api/batch/v1"
@@ -12,14 +13,11 @@ import (
 type ManageJobType string
 
 const (
-	// DBSyncCommand -
-	// TODO: Once we work on update/upgrades revisit the command in the
-	//       the db-sync-config.json file.
-	//       If we stop all services during the update/upgrade then we can keep
-	//       the --bump-versions flag.
-	//       If we are doing rolling upgrades we'll need to use the flag
-	//       conditionally (only for adoption) and do the restart cycle of
-	//       services as described in the upstream rolling upgrades process.
+	// DBSyncCommand - direct cinder-manage command without kolla wrapper
+	// TODO: Once we work on update/upgrades we'll need to use the
+	//       --bump-versions flag conditionally (only for adoption) and do
+	//       the restart cycle of services as described in the upstream
+	//       rolling upgrades process.
 	DBSyncCommand = "/usr/bin/cinder-manage --config-dir /etc/cinder/cinder.conf.d db sync --bump-versions"
 	// OnlineDataMigrationsCommand - for running online data migrations during upgrades
 	OnlineDataMigrationsCommand = "/usr/bin/cinder-manage --config-dir /etc/cinder/cinder.conf.d db online_data_migrations"
@@ -30,24 +28,14 @@ const (
 )
 
 // ManageJob - creates a job for running various cinder-manage commands
-func ManageJob(instance *cinderv1beta1.Cinder, jobType ManageJobType, labels map[string]string, annotations map[string]string) *batchv1.Job {
+func ManageJob(
+	instance *cinderv1beta1.Cinder,
+	labels map[string]string,
+	annotations map[string]string,
+	jobNameSuffix ManageJobType,
+	command string,
+) *batchv1.Job {
 	var config0644AccessMode int32 = 0644
-
-	// Determine job name suffix and command based on job type
-	var jobNameSuffix string
-	var command string
-
-	switch jobType {
-	case DbSyncJobType:
-		jobNameSuffix = "db-sync"
-		command = DBSyncCommand
-	case OnlineDataMigrationsJobType:
-		jobNameSuffix = "online-data-migrations"
-		command = OnlineDataMigrationsCommand
-	default:
-		jobNameSuffix = "db-sync"
-		command = DBSyncCommand
-	}
 
 	// Unlike the individual cinder services, cinder-manage jobs don't need a
 	// secret that contains all of the config snippets required by every
@@ -97,7 +85,7 @@ func ManageJob(instance *cinderv1beta1.Cinder, jobType ManageJobType, labels map
 
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      instance.Name + "-" + jobNameSuffix,
+			Name:      fmt.Sprintf("%s-%s", instance.Name, string(jobNameSuffix)),
 			Namespace: instance.Namespace,
 			Labels:    labels,
 		},
@@ -111,7 +99,7 @@ func ManageJob(instance *cinderv1beta1.Cinder, jobType ManageJobType, labels map
 					ServiceAccountName: instance.RbacResourceName(),
 					Containers: []corev1.Container{
 						{
-							Name: instance.Name + "-" + jobNameSuffix,
+							Name: fmt.Sprintf("%s-%s", instance.Name, string(jobNameSuffix)),
 							Command: []string{
 								"/bin/bash",
 							},
@@ -139,10 +127,10 @@ func ManageJob(instance *cinderv1beta1.Cinder, jobType ManageJobType, labels map
 
 // DbSyncJob func - backward compatible wrapper for database sync
 func DbSyncJob(instance *cinderv1beta1.Cinder, labels map[string]string, annotations map[string]string) *batchv1.Job {
-	return ManageJob(instance, DbSyncJobType, labels, annotations)
+	return ManageJob(instance, labels, annotations, DbSyncJobType, DBSyncCommand)
 }
 
 // OnlineDataMigrationsJob creates a job for running cinder-manage db online_data_migrations
 func OnlineDataMigrationsJob(instance *cinderv1beta1.Cinder, labels map[string]string, annotations map[string]string) *batchv1.Job {
-	return ManageJob(instance, OnlineDataMigrationsJobType, labels, annotations)
+	return ManageJob(instance, labels, annotations, OnlineDataMigrationsJobType, OnlineDataMigrationsCommand)
 }

--- a/internal/controller/cinder_controller.go
+++ b/internal/controller/cinder_controller.go
@@ -193,6 +193,7 @@ func (r *CinderReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 		condition.UnknownCondition(condition.ReadyCondition, condition.InitReason, condition.ReadyInitMessage),
 		condition.UnknownCondition(condition.DBReadyCondition, condition.InitReason, condition.DBReadyInitMessage),
 		condition.UnknownCondition(condition.DBSyncReadyCondition, condition.InitReason, condition.DBSyncReadyInitMessage),
+		condition.UnknownCondition(cinderv1beta1.OnlineDataMigrationReadyCondition, condition.InitReason, cinderv1beta1.OnlineDataMigrationReadyInitMessage),
 		condition.UnknownCondition(condition.RabbitMqTransportURLReadyCondition, condition.InitReason, condition.RabbitMqTransportURLReadyInitMessage),
 		condition.UnknownCondition(condition.MemcachedReadyCondition, condition.InitReason, condition.MemcachedReadyInitMessage),
 		condition.UnknownCondition(condition.InputReadyCondition, condition.InitReason, condition.InputReadyInitMessage),
@@ -499,6 +500,48 @@ func (r *CinderReconciler) reconcileInit(
 	instance.Status.Conditions.MarkTrue(condition.DBSyncReadyCondition, condition.DBSyncReadyMessage)
 
 	// run Cinder db sync - end
+
+	//
+	// run Cinder online data migrations
+	//
+	migrationHash := instance.Status.Hash[cinderv1beta1.OnlineDataMigrationHash]
+	migrationJobDef := cinder.OnlineDataMigrationsJob(instance, serviceLabels, serviceAnnotations)
+
+	migrationJob := job.NewJob(
+		migrationJobDef,
+		cinderv1beta1.OnlineDataMigrationHash,
+		instance.Spec.PreserveJobs,
+		cinder.ShortDuration,
+		migrationHash,
+	)
+	ctrlResult, err = migrationJob.DoJob(
+		ctx,
+		helper,
+	)
+	if (ctrlResult != ctrl.Result{}) {
+		instance.Status.Conditions.Set(condition.FalseCondition(
+			cinderv1beta1.OnlineDataMigrationReadyCondition,
+			condition.RequestedReason,
+			condition.SeverityInfo,
+			cinderv1beta1.OnlineDataMigrationReadyRunningMessage))
+		return ctrlResult, nil
+	}
+	if err != nil {
+		instance.Status.Conditions.Set(condition.FalseCondition(
+			cinderv1beta1.OnlineDataMigrationReadyCondition,
+			condition.ErrorReason,
+			condition.SeverityWarning,
+			cinderv1beta1.OnlineDataMigrationReadyErrorMessage,
+			err.Error()))
+		return ctrl.Result{}, err
+	}
+	if migrationJob.HasChanged() {
+		instance.Status.Hash[cinderv1beta1.OnlineDataMigrationHash] = migrationJob.GetHash()
+		Log.Info(fmt.Sprintf("Service '%s' - Job %s hash added - %s", instance.Name, migrationJobDef.Name, instance.Status.Hash[cinderv1beta1.OnlineDataMigrationHash]))
+	}
+	instance.Status.Conditions.MarkTrue(cinderv1beta1.OnlineDataMigrationReadyCondition, cinderv1beta1.OnlineDataMigrationReadyMessage)
+
+	// run Cinder online data migrations - end
 
 	Log.Info(fmt.Sprintf("Reconciled Service '%s' init successfully", instance.Name))
 	return ctrl.Result{}, nil

--- a/templates/cinder/config/db-sync-config.json
+++ b/templates/cinder/config/db-sync-config.json
@@ -1,3 +1,0 @@
-{
-  "command": "/usr/bin/cinder-manage --config-dir /etc/cinder/cinder.conf.d db sync --bump-versions"
-}

--- a/test/functional/cinder_controller_test.go
+++ b/test/functional/cinder_controller_test.go
@@ -108,7 +108,7 @@ var _ = Describe("Cinder controller", func() {
 		It("initializes the status fields", func() {
 			Eventually(func(g Gomega) {
 				cinder := GetCinder(cinderName)
-				g.Expect(cinder.Status.Conditions).To(HaveLen(16))
+				g.Expect(cinder.Status.Conditions).To(HaveLen(17))
 
 				g.Expect(cinder.Status.DatabaseHostname).To(Equal(""))
 			}, timeout*2, interval).Should(Succeed())
@@ -224,6 +224,7 @@ var _ = Describe("Cinder controller", func() {
 			mariadb.SimulateMariaDBAccountCompleted(cinderTest.Database)
 			mariadb.SimulateMariaDBDatabaseCompleted(cinderTest.Database)
 			th.SimulateJobSuccess(cinderTest.CinderDBSync)
+			th.SimulateJobSuccess(cinderTest.CinderOnlineDataMigration)
 			Cinder := GetCinder(cinderTest.Instance)
 			Expect(Cinder.Status.DatabaseHostname).To(Equal(fmt.Sprintf("hostname-for-openstack.%s.svc", namespace)))
 			th.ExpectCondition(
@@ -231,12 +232,6 @@ var _ = Describe("Cinder controller", func() {
 				ConditionGetterFunc(CinderConditionGetter),
 				condition.DBReadyCondition,
 				corev1.ConditionTrue,
-			)
-			th.ExpectCondition(
-				cinderName,
-				ConditionGetterFunc(CinderConditionGetter),
-				condition.DBSyncReadyCondition,
-				corev1.ConditionFalse,
 			)
 		})
 		It("Should fail if db-sync job fails when DB is Created", func() {
@@ -253,6 +248,18 @@ var _ = Describe("Cinder controller", func() {
 				cinderTest.Instance,
 				ConditionGetterFunc(CinderConditionGetter),
 				condition.DBSyncReadyCondition,
+				corev1.ConditionFalse,
+			)
+		})
+		It("Should fail if online-data-migrations job fails when DB is Created", func() {
+			mariadb.SimulateMariaDBAccountCompleted(cinderTest.Database)
+			mariadb.SimulateMariaDBDatabaseCompleted(cinderTest.Database)
+			th.SimulateJobSuccess(cinderTest.CinderDBSync)
+			th.SimulateJobFailure(cinderTest.CinderOnlineDataMigration)
+			th.ExpectCondition(
+				cinderTest.Instance,
+				ConditionGetterFunc(CinderConditionGetter),
+				cinderv1.OnlineDataMigrationReadyCondition,
 				corev1.ConditionFalse,
 			)
 		})
@@ -383,6 +390,7 @@ var _ = Describe("Cinder controller", func() {
 			mariadb.SimulateMariaDBAccountCompleted(cinderTest.Database)
 			mariadb.SimulateMariaDBDatabaseCompleted(cinderTest.Database)
 			th.SimulateJobSuccess(cinderTest.CinderDBSync)
+			th.SimulateJobSuccess(cinderTest.CinderOnlineDataMigration)
 			keystone.SimulateKeystoneServiceReady(cinderTest.CinderKeystoneService)
 			keystone.SimulateKeystoneEndpointReady(cinderTest.CinderKeystoneEndpoint)
 		})
@@ -426,6 +434,7 @@ var _ = Describe("Cinder controller", func() {
 			mariadb.SimulateMariaDBAccountCompleted(cinderTest.Database)
 			mariadb.SimulateMariaDBDatabaseCompleted(cinderTest.Database)
 			th.SimulateJobSuccess(cinderTest.CinderDBSync)
+			th.SimulateJobSuccess(cinderTest.CinderOnlineDataMigration)
 			keystone.SimulateKeystoneServiceReady(cinderTest.CinderKeystoneService)
 			keystone.SimulateKeystoneEndpointReady(cinderTest.CinderKeystoneEndpoint)
 		})
@@ -468,6 +477,7 @@ var _ = Describe("Cinder controller", func() {
 			mariadb.SimulateMariaDBAccountCompleted(cinderTest.Database)
 			mariadb.SimulateMariaDBDatabaseCompleted(cinderTest.Database)
 			th.SimulateJobSuccess(cinderTest.CinderDBSync)
+			th.SimulateJobSuccess(cinderTest.CinderOnlineDataMigration)
 		})
 		It("removes the finalizers from the Cinder DB", func() {
 			keystone.SimulateKeystoneServiceReady(cinderTest.CinderKeystoneService)
@@ -552,6 +562,7 @@ var _ = Describe("Cinder controller", func() {
 			mariadb.SimulateMariaDBAccountCompleted(cinderTest.Database)
 			mariadb.SimulateMariaDBDatabaseCompleted(cinderTest.Database)
 			th.SimulateJobSuccess(cinderTest.CinderDBSync)
+			th.SimulateJobSuccess(cinderTest.CinderOnlineDataMigration)
 			th.SimulateLoadBalancerServiceIP(cinderTest.CinderServiceInternal)
 			keystone.SimulateKeystoneServiceReady(cinderTest.CinderKeystoneService)
 		})
@@ -627,6 +638,7 @@ var _ = Describe("Cinder controller", func() {
 			mariadb.SimulateMariaDBAccountCompleted(cinderTest.Database)
 			mariadb.SimulateMariaDBTLSDatabaseCompleted(cinderTest.Database)
 			th.SimulateJobSuccess(cinderTest.CinderDBSync)
+			th.SimulateJobSuccess(cinderTest.CinderOnlineDataMigration)
 		})
 
 		It("reports that the CA secret is missing", func() {
@@ -856,6 +868,7 @@ var _ = Describe("Cinder controller", func() {
 			mariadb.SimulateMariaDBAccountCompleted(cinderTest.Database)
 			mariadb.SimulateMariaDBDatabaseCompleted(cinderTest.Database)
 			th.SimulateJobSuccess(cinderTest.CinderDBSync)
+			th.SimulateJobSuccess(cinderTest.CinderOnlineDataMigration)
 			keystone.SimulateKeystoneServiceReady(cinderTest.CinderKeystoneService)
 			keystone.SimulateKeystoneEndpointReady(cinderTest.CinderKeystoneEndpoint)
 			th.SimulateStatefulSetReplicaReady(cinderTest.CinderAPI)
@@ -1100,6 +1113,7 @@ var _ = Describe("Cinder controller", func() {
 			mariadb.SimulateMariaDBAccountCompleted(cinderTest.Database)
 			mariadb.SimulateMariaDBDatabaseCompleted(cinderTest.Database)
 			th.SimulateJobSuccess(cinderTest.CinderDBSync)
+			th.SimulateJobSuccess(cinderTest.CinderOnlineDataMigration)
 			keystone.SimulateKeystoneServiceReady(cinderTest.CinderKeystoneService)
 			keystone.SimulateKeystoneEndpointReady(cinderTest.CinderKeystoneEndpoint)
 			th.SimulateStatefulSetReplicaReady(cinderTest.CinderAPI)
@@ -1137,6 +1151,7 @@ var _ = Describe("Cinder controller", func() {
 
 			Eventually(func(g Gomega) {
 				th.SimulateJobSuccess(cinderTest.CinderDBSync)
+				th.SimulateJobSuccess(cinderTest.CinderOnlineDataMigration)
 				g.Expect(th.GetStatefulSet(cinderTest.CinderAPI).Spec.Template.Spec.NodeSelector).To(Equal(map[string]string{"foo2": "bar2"}))
 				g.Expect(th.GetStatefulSet(cinderTest.CinderScheduler).Spec.Template.Spec.NodeSelector).To(Equal(map[string]string{"foo2": "bar2"}))
 				g.Expect(th.GetStatefulSet(cinderTest.CinderVolumes[0]).Spec.Template.Spec.NodeSelector).To(Equal(map[string]string{"foo2": "bar2"}))
@@ -1163,6 +1178,7 @@ var _ = Describe("Cinder controller", func() {
 
 			Eventually(func(g Gomega) {
 				th.SimulateJobSuccess(cinderTest.CinderDBSync)
+				th.SimulateJobSuccess(cinderTest.CinderOnlineDataMigration)
 				g.Expect(th.GetStatefulSet(cinderTest.CinderAPI).Spec.Template.Spec.NodeSelector).To(BeNil())
 				g.Expect(th.GetStatefulSet(cinderTest.CinderScheduler).Spec.Template.Spec.NodeSelector).To(BeNil())
 				g.Expect(th.GetStatefulSet(cinderTest.CinderVolumes[0]).Spec.Template.Spec.NodeSelector).To(BeNil())
@@ -1188,6 +1204,7 @@ var _ = Describe("Cinder controller", func() {
 
 			Eventually(func(g Gomega) {
 				th.SimulateJobSuccess(cinderTest.CinderDBSync)
+				th.SimulateJobSuccess(cinderTest.CinderOnlineDataMigration)
 				g.Expect(th.GetStatefulSet(cinderTest.CinderAPI).Spec.Template.Spec.NodeSelector).To(BeNil())
 				g.Expect(th.GetStatefulSet(cinderTest.CinderScheduler).Spec.Template.Spec.NodeSelector).To(BeNil())
 				g.Expect(th.GetStatefulSet(cinderTest.CinderVolumes[0]).Spec.Template.Spec.NodeSelector).To(BeNil())
@@ -1226,6 +1243,7 @@ var _ = Describe("Cinder controller", func() {
 
 			Eventually(func(g Gomega) {
 				th.SimulateJobSuccess(cinderTest.CinderDBSync)
+				th.SimulateJobSuccess(cinderTest.CinderOnlineDataMigration)
 				g.Expect(th.GetStatefulSet(cinderTest.CinderAPI).Spec.Template.Spec.NodeSelector).To(Equal(map[string]string{"foo": "api"}))
 				g.Expect(th.GetStatefulSet(cinderTest.CinderScheduler).Spec.Template.Spec.NodeSelector).To(Equal(map[string]string{"foo": "scheduler"}))
 				g.Expect(th.GetStatefulSet(cinderTest.CinderVolumes[0]).Spec.Template.Spec.NodeSelector).To(Equal(map[string]string{"foo": "volume"}))
@@ -1258,6 +1276,7 @@ var _ = Describe("Cinder controller", func() {
 
 			Eventually(func(g Gomega) {
 				th.SimulateJobSuccess(cinderTest.CinderDBSync)
+				th.SimulateJobSuccess(cinderTest.CinderOnlineDataMigration)
 				g.Expect(th.GetStatefulSet(cinderTest.CinderAPI).Spec.Template.Spec.NodeSelector).To(BeNil())
 				g.Expect(th.GetStatefulSet(cinderTest.CinderScheduler).Spec.Template.Spec.NodeSelector).To(BeNil())
 				g.Expect(th.GetStatefulSet(cinderTest.CinderVolumes[0]).Spec.Template.Spec.NodeSelector).To(BeNil())
@@ -1310,6 +1329,7 @@ var _ = Describe("Cinder controller", func() {
 			mariadb.SimulateMariaDBAccountCompleted(cinderTest.Database)
 			mariadb.SimulateMariaDBDatabaseCompleted(cinderTest.Database)
 			th.SimulateJobSuccess(cinderTest.CinderDBSync)
+			th.SimulateJobSuccess(cinderTest.CinderOnlineDataMigration)
 			keystone.SimulateKeystoneEndpointReady(cinderTest.CinderKeystoneEndpoint)
 		})
 
@@ -1384,6 +1404,7 @@ var _ = Describe("Cinder controller", func() {
 			mariadb.SimulateMariaDBAccountCompleted(cinderTest.Database)
 			mariadb.SimulateMariaDBDatabaseCompleted(cinderTest.Database)
 			th.SimulateJobSuccess(cinderTest.CinderDBSync)
+			th.SimulateJobSuccess(cinderTest.CinderOnlineDataMigration)
 			keystone.SimulateKeystoneEndpointReady(cinderTest.CinderKeystoneEndpoint)
 		})
 		It("Checks the status contains the notifications TransportURL entry", func() {
@@ -1461,6 +1482,7 @@ var _ = Describe("Cinder controller", func() {
 			mariadb.SimulateMariaDBAccountCompleted(accountName)
 			mariadb.SimulateMariaDBDatabaseCompleted(cinderTest.Database)
 			th.SimulateJobSuccess(cinderTest.CinderDBSync)
+			th.SimulateJobSuccess(cinderTest.CinderOnlineDataMigration)
 
 			DeferCleanup(k8sClient.Delete, ctx, th.CreateCABundleSecret(cinderTest.CABundleSecret))
 			DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(cinderTest.InternalCertSecret))
@@ -1536,6 +1558,7 @@ var _ = Describe("Cinder with RabbitMQ Quorum Queues", func() {
 
 		It("should generate config with quorum queue settings when enabled", func() {
 			th.SimulateJobSuccess(cinderTest.CinderDBSync)
+			th.SimulateJobSuccess(cinderTest.CinderOnlineDataMigration)
 			keystone.SimulateKeystoneServiceReady(cinderTest.CinderKeystoneService)
 			keystone.SimulateKeystoneEndpointReady(cinderTest.CinderKeystoneEndpoint)
 
@@ -1577,6 +1600,7 @@ var _ = Describe("Cinder with RabbitMQ Quorum Queues", func() {
 
 		It("should update config when quorum queues are enabled after being disabled", func() {
 			th.SimulateJobSuccess(cinderTest.CinderDBSync)
+			th.SimulateJobSuccess(cinderTest.CinderOnlineDataMigration)
 			keystone.SimulateKeystoneServiceReady(cinderTest.CinderKeystoneService)
 			keystone.SimulateKeystoneEndpointReady(cinderTest.CinderKeystoneEndpoint)
 
@@ -1640,6 +1664,7 @@ var _ = Describe("Cinder with RabbitMQ Quorum Queues", func() {
 
 		It("should generate config without quorum queue settings when not specified", func() {
 			th.SimulateJobSuccess(cinderTest.CinderDBSync)
+			th.SimulateJobSuccess(cinderTest.CinderOnlineDataMigration)
 			keystone.SimulateKeystoneServiceReady(cinderTest.CinderKeystoneService)
 			keystone.SimulateKeystoneEndpointReady(cinderTest.CinderKeystoneEndpoint)
 
@@ -1954,6 +1979,7 @@ var _ = Describe("Cinder Webhook", func() {
 			mariadb.SimulateMariaDBDatabaseCompleted(cinderTest.Database)
 
 			th.SimulateJobSuccess(cinderTest.CinderDBSync)
+			th.SimulateJobSuccess(cinderTest.CinderOnlineDataMigration)
 
 			keystone.SimulateKeystoneEndpointReady(cinderTest.CinderKeystoneEndpoint)
 		})
@@ -2124,6 +2150,7 @@ var _ = Describe("Cinder Webhook", func() {
 			mariadb.SimulateMariaDBAccountCompleted(cinderTest.Database)
 			mariadb.SimulateMariaDBDatabaseCompleted(cinderTest.Database)
 			th.SimulateJobSuccess(cinderTest.CinderDBSync)
+			th.SimulateJobSuccess(cinderTest.CinderOnlineDataMigration)
 			keystone.SimulateKeystoneServiceReady(cinderTest.CinderKeystoneService)
 			keystone.SimulateKeystoneEndpointReady(cinderTest.CinderKeystoneEndpoint)
 			th.SimulateStatefulSetReplicaReady(cinderTest.CinderAPI)
@@ -2687,6 +2714,7 @@ var _ = Describe("Cinder config secret recreation", func() {
 			mariadb.SimulateMariaDBAccountCompleted(cinderTest.Database)
 			mariadb.SimulateMariaDBDatabaseCompleted(cinderTest.Database)
 			th.SimulateJobSuccess(cinderTest.CinderDBSync)
+			th.SimulateJobSuccess(cinderTest.CinderOnlineDataMigration)
 			keystone.SimulateKeystoneServiceReady(cinderTest.CinderKeystoneService)
 			keystone.SimulateKeystoneEndpointReady(cinderTest.CinderKeystoneEndpoint)
 		})

--- a/test/functional/cinder_test_data.go
+++ b/test/functional/cinder_test_data.go
@@ -63,6 +63,7 @@ type CinderTestData struct {
 	CinderMemcached                types.NamespacedName
 	CinderSA                       types.NamespacedName
 	CinderDBSync                   types.NamespacedName
+	CinderOnlineDataMigration      types.NamespacedName
 	CinderDBPurge                  types.NamespacedName
 	CinderKeystoneService          types.NamespacedName
 	CinderKeystoneEndpoint         types.NamespacedName
@@ -99,6 +100,10 @@ func GetCinderTestData(cinderName types.NamespacedName) CinderTestData {
 		CinderDBSync: types.NamespacedName{
 			Namespace: cinderName.Namespace,
 			Name:      fmt.Sprintf("%s-db-sync", cinderName.Name),
+		},
+		CinderOnlineDataMigration: types.NamespacedName{
+			Namespace: cinderName.Namespace,
+			Name:      fmt.Sprintf("%s-online-data-migrations", cinderName.Name),
 		},
 		CinderDBPurge: types.NamespacedName{
 			Namespace: cinderName.Namespace,


### PR DESCRIPTION
Enhance the existing job interface to support multiple `cinder-manage` commands.
The main purpose of this patch is to introduce the ability to run `online_data_migration`, required in the upgrade context and described in the upstream documentation [1].
For this reason, this patch:
- adds a generic `CinderManageJob()` function with job type parameter
- implements an `OnlineDataMigrationsJob()`, useful for upgrade scenarios
- keeps backward compatibility with existing `DbSyncJob()`

Jira: [OSPRH-1559](https://redhat.atlassian.net/browse/OSPRH-1559) 

[1] https://docs.openstack.org/cinder/latest/admin/upgrades.html