### PR TITLE
Add application credential finalizer management

### DIFF
--- a/api/bases/cinder.openstack.org_cinders.yaml
+++ b/api/bases/cinder.openstack.org_cinders.yaml
@@ -2604,6 +2604,10 @@ spec:
                   type: object
                 description: API endpoints
                 type: object
+              applicationCredentialSecret:
+                description: ApplicationCredentialSecret - the AC secret cinder is
+                  currently consuming
+                type: string
               cinderAPIReadyCount:
                 default: 0
                 description: ReadyCount of Cinder API instance

--- a/api/v1beta1/cinder_types.go
+++ b/api/v1beta1/cinder_types.go
@@ -236,6 +236,9 @@ type CinderStatus struct {
 	// controller has not started processing the latest changes, and the status
 	// and its conditions are likely stale.
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+
+	// ApplicationCredentialSecret - the AC secret cinder is currently consuming
+	ApplicationCredentialSecret string `json:"applicationCredentialSecret,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/config/crd/bases/cinder.openstack.org_cinders.yaml
+++ b/config/crd/bases/cinder.openstack.org_cinders.yaml
@@ -2604,6 +2604,10 @@ spec:
                   type: object
                 description: API endpoints
                 type: object
+              applicationCredentialSecret:
+                description: ApplicationCredentialSecret - the AC secret cinder is
+                  currently consuming
+                type: string
               cinderAPIReadyCount:
                 default: 0
                 description: ReadyCount of Cinder API instance

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.6.1-0.20260518125357-72bdd580c587
 	github.com/openstack-k8s-operators/lib-common/modules/storage v0.6.1-0.20260518125357-72bdd580c587
 	github.com/openstack-k8s-operators/lib-common/modules/test v0.6.1-0.20260518125357-72bdd580c587
-	github.com/openstack-k8s-operators/mariadb-operator/api v0.6.1-0.20260520170827-2312ad5047f0
+	github.com/openstack-k8s-operators/mariadb-operator/api v0.6.1-0.20260421135251-4fb605db7d18
 	golang.org/x/exp v0.0.0-20241217172543-b2144cdd0a67
 	k8s.io/api v0.31.14
 	k8s.io/apimachinery v0.31.14
@@ -24,7 +24,7 @@ require (
 
 require (
 	github.com/openstack-k8s-operators/cinder-operator/api v0.0.0-00010101000000-000000000000
-	gopkg.in/ini.v1 v1.67.2
+	gopkg.in/ini.v1 v1.67.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -130,8 +130,8 @@ github.com/openstack-k8s-operators/lib-common/modules/storage v0.6.1-0.202605181
 github.com/openstack-k8s-operators/lib-common/modules/storage v0.6.1-0.20260518125357-72bdd580c587/go.mod h1:4UPRrHSuvNj1Ep10VWb7GK+jELc31n94qhBwkTwxrA4=
 github.com/openstack-k8s-operators/lib-common/modules/test v0.6.1-0.20260518125357-72bdd580c587 h1:jpouKcgs2Kc5z2JHIpvsXMxEonfXLgzX3KswuBoeKQ0=
 github.com/openstack-k8s-operators/lib-common/modules/test v0.6.1-0.20260518125357-72bdd580c587/go.mod h1:nLS2oK4pBo756JNN1cPgr44S0X9V11QScgVla89Ojok=
-github.com/openstack-k8s-operators/mariadb-operator/api v0.6.1-0.20260520170827-2312ad5047f0 h1:DDyivo23YdEIJbW5z9Lbo4Fo+hRWYW1/N8IdIcWDNWw=
-github.com/openstack-k8s-operators/mariadb-operator/api v0.6.1-0.20260520170827-2312ad5047f0/go.mod h1:/9N3XCC/QR2CowKaVmz1R5BP9NVJxL6RAb6aplOYGe8=
+github.com/openstack-k8s-operators/mariadb-operator/api v0.6.1-0.20260421135251-4fb605db7d18 h1:fMMY6pp7+PEkcsdDoodTfJ6ct2RyGI8VB+toVJxxB5w=
+github.com/openstack-k8s-operators/mariadb-operator/api v0.6.1-0.20260421135251-4fb605db7d18/go.mod h1:g/xgMnzNHxdTkqnEgAKwVOv75uPN4nuApbkGqSvASvs=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -270,8 +270,8 @@ gopkg.in/evanphx/json-patch.v4 v4.12.0 h1:n6jtcsulIzXPJaxegRbvFNNrZDjbij7ny3gmSP
 gopkg.in/evanphx/json-patch.v4 v4.12.0/go.mod h1:p8EYWUEYMpynmqDbY58zCKCFZw8pRWMG4EsWvDvM72M=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
-gopkg.in/ini.v1 v1.67.2 h1:JtOSMb9OuaCZKr7h5D/h6iii14sK0hLbplTc6frx4Ss=
-gopkg.in/ini.v1 v1.67.2/go.mod h1:x/cyOwCgZqOkJoDIJ3c1KNHMo10+nLGAhh+kn3Zizss=
+gopkg.in/ini.v1 v1.67.1 h1:tVBILHy0R6e4wkYOn3XmiITt/hEVH4TFMYvAX2Ytz6k=
+gopkg.in/ini.v1 v1.67.1/go.mod h1:x/cyOwCgZqOkJoDIJ3c1KNHMo10+nLGAhh+kn3Zizss=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/internal/cinder/const.go
+++ b/internal/cinder/const.go
@@ -76,6 +76,9 @@ const (
 	// https://opendev.org/openstack/cinder/src/branch/master/cinder/common/config.py#L121
 	CinderServiceDownTime = 60
 
+	// ACConsumerFinalizer is added to AC secrets that cinder is actively consuming
+	ACConsumerFinalizer = "openstack.org/cinder-ac-consumer"
+
 	// ShortDuration is a short duration for quick retries
 	ShortDuration = time.Duration(5) * time.Second
 	// NormalDuration is the normal duration for standard retries

--- a/internal/controller/cinder_controller.go
+++ b/internal/controller/cinder_controller.go
@@ -441,6 +441,19 @@ func (r *CinderReconciler) reconcileDelete(ctx context.Context, instance *cinder
 	// TODO: We might need to control how the sub-services (API, Backup, Scheduler and Volumes) are
 	// deleted (when their parent Cinder CR is deleted) once we further develop their functionality
 
+	// Remove consumer finalizer from AC secrets cinder was consuming.
+	// Check both status and spec to handle the edge case where the reconciler
+	// crashed after adding the finalizer but before updating the status.
+	for _, secretName := range []string{
+		instance.Status.ApplicationCredentialSecret,
+		instance.Spec.Auth.ApplicationCredentialSecret,
+	} {
+		if err := keystonev1.RemoveACSecretConsumerFinalizer(ctx, helper, instance.Namespace,
+			secretName, cinder.ACConsumerFinalizer); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
 	// Service is deleted so remove the finalizer.
 	controllerutil.RemoveFinalizer(instance, helper.GetFinalizer())
 	Log.Info(fmt.Sprintf("Reconciled Service '%s' delete successfully", instance.Name))
@@ -778,6 +791,24 @@ func (r *CinderReconciler) reconcileNormal(ctx context.Context, instance *cinder
 		return ctrl.Result{}, nil
 	}
 
+	// Add consumer finalizer to the new AC secret early, before deployment.
+	// The old secret's finalizer is removed later (after all services deploy)
+	// so that rapid rotations don't revoke a credential still in use by pods.
+	if instance.Spec.Auth.ApplicationCredentialSecret != "" {
+		if err := keystonev1.ManageACSecretFinalizer(ctx, helper, instance.Namespace,
+			instance.Spec.Auth.ApplicationCredentialSecret,
+			"",
+			cinder.ACConsumerFinalizer); err != nil {
+			instance.Status.Conditions.Set(condition.FalseCondition(
+				condition.ServiceConfigReadyCondition,
+				condition.ErrorReason,
+				condition.SeverityWarning,
+				condition.ServiceConfigReadyErrorMessage,
+				err.Error()))
+			return ctrl.Result{}, err
+		}
+	}
+
 	instance.Status.Conditions.MarkTrue(condition.ServiceConfigReadyCondition, condition.ServiceConfigReadyMessage)
 
 	//
@@ -1082,6 +1113,26 @@ func (r *CinderReconciler) reconcileNormal(ctx context.Context, instance *cinder
 	}
 
 	Log.Info(fmt.Sprintf("Reconciled Service '%s' successfully", instance.Name))
+
+	// Manage the old AC secret's finalizer and status tracking.
+	// On rotation (old != new), only remove the old secret's finalizer after
+	// all sub-services are ready with the new credentials. This prevents
+	// premature revocation during rapid rotations.
+	isRotation := instance.Status.ApplicationCredentialSecret != "" && instance.Status.ApplicationCredentialSecret != instance.Spec.Auth.ApplicationCredentialSecret
+
+	if isRotation {
+		allServicesReady := instance.Status.Conditions.AllSubConditionIsTrue()
+		if allServicesReady {
+			if err := keystonev1.RemoveACSecretConsumerFinalizer(ctx, helper, instance.Namespace,
+				instance.Status.ApplicationCredentialSecret, cinder.ACConsumerFinalizer); err != nil {
+				return ctrl.Result{}, err
+			}
+			instance.Status.ApplicationCredentialSecret = instance.Spec.Auth.ApplicationCredentialSecret
+		}
+	} else {
+		instance.Status.ApplicationCredentialSecret = instance.Spec.Auth.ApplicationCredentialSecret
+	}
+
 	// update the overall status condition if service is ready
 	if instance.IsReady() {
 		instance.Status.Conditions.MarkTrue(condition.ReadyCondition, condition.ReadyMessage)

--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -415,6 +415,17 @@ func GetCinderSpecWithAC(acSecretName string) map[string]interface{} {
 	spec["auth"] = map[string]interface{}{
 		"applicationCredentialSecret": acSecretName,
 	}
+	// GetDefaultCinderSpec uses the legacy "cinderVolume" key which is not part
+	// of the CRD schema; use cinderVolumes so sub-CRs and StatefulSets are created.
+	delete(spec, "cinderVolume")
+	spec["cinderVolumes"] = map[string]any{
+		"volume1": map[string]any{},
+	}
+	// Keep the AC test layout minimal (API + scheduler + one volume), matching
+	// the topology functional test and avoiding backup reconcile overhead.
+	backupSpec := GetDefaultCinderBackupSpec()
+	backupSpec["replicas"] = 0
+	spec["cinderBackup"] = backupSpec
 	return spec
 }
 

--- a/test/functional/cinder_controller_test.go
+++ b/test/functional/cinder_controller_test.go
@@ -2221,6 +2221,215 @@ var _ = Describe("Cinder Webhook", func() {
 			}, timeout, interval).Should(Succeed())
 		})
 	})
+
+	When("ApplicationCredential consumer finalizer is managed", func() {
+		var (
+			acSecretName          string
+			servicePasswordSecret string
+		)
+
+		BeforeEach(func() {
+			servicePasswordSecret = ACTestServicePasswordSecret
+
+			DeferCleanup(k8sClient.Delete, ctx,
+				CreateCinderMessageBusSecret(
+					cinderTest.Instance.Namespace,
+					cinderTest.RabbitmqSecretName,
+				),
+			)
+			DeferCleanup(k8sClient.Delete, ctx,
+				CreateCinderSecret(cinderTest.Instance.Namespace, servicePasswordSecret))
+
+			acSecretName = "ac-cinder-a1b2c-secret" //nolint:gosec // G101
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: cinderTest.Instance.Namespace,
+					Name:      acSecretName,
+				},
+				Data: map[string][]byte{
+					keystonev1.ACIDSecretKey:     []byte("a1b2ctest-ac-id"),
+					keystonev1.ACSecretSecretKey: []byte("test-ac-secret"),
+				},
+			}
+			DeferCleanup(k8sClient.Delete, ctx, secret)
+			Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+
+			spec := GetCinderSpecWithAC(acSecretName)
+			DeferCleanup(th.DeleteInstance, CreateCinder(cinderTest.Instance, spec))
+			DeferCleanup(
+				mariadb.DeleteDBService,
+				mariadb.CreateDBService(
+					cinderTest.Instance.Namespace,
+					GetCinder(cinderTest.Instance).Spec.DatabaseInstance,
+					corev1.ServiceSpec{
+						Ports: []corev1.ServicePort{{Port: 3306}}}))
+
+			acc, accSecret := mariadb.CreateMariaDBAccountAndSecret(cinderTest.Database, mariadbv1.MariaDBAccountSpec{})
+			DeferCleanup(k8sClient.Delete, ctx, acc)
+			DeferCleanup(k8sClient.Delete, ctx, accSecret)
+			mariadb.CreateMariaDBDatabase(cinderTest.Database.Namespace, cinderTest.Database.Name, mariadbv1.MariaDBDatabaseSpec{})
+			DeferCleanup(k8sClient.Delete, ctx, mariadb.GetMariaDBDatabase(cinderTest.Database))
+
+			DeferCleanup(keystone.DeleteKeystoneAPI,
+				keystone.CreateKeystoneAPI(cinderTest.Instance.Namespace))
+
+			DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(cinderTest.Instance.Namespace, MemcachedInstance, memcachedv1.MemcachedSpec{}))
+			infra.SimulateMemcachedReady(cinderTest.CinderMemcached)
+
+			infra.SimulateTransportURLReady(cinderTest.CinderTransportURL)
+			mariadb.SimulateMariaDBAccountCompleted(cinderTest.Database)
+			mariadb.SimulateMariaDBDatabaseCompleted(cinderTest.Database)
+			th.SimulateJobSuccess(cinderTest.CinderDBSync)
+			th.SimulateJobSuccess(cinderTest.CinderOnlineDataMigration)
+			keystone.SimulateKeystoneServiceReady(cinderTest.CinderKeystoneService)
+			keystone.SimulateKeystoneEndpointReady(cinderTest.CinderKeystoneEndpoint)
+		})
+
+		It("should add the consumer finalizer to the AC secret", func() {
+			Eventually(func(g Gomega) {
+				secret := th.GetSecret(types.NamespacedName{
+					Namespace: cinderTest.Instance.Namespace,
+					Name:      acSecretName,
+				})
+				g.Expect(secret.Finalizers).To(
+					ContainElement(cinder.ACConsumerFinalizer))
+			}, timeout, interval).Should(Succeed())
+		})
+
+		It("should track the consumed AC secret in status", func() {
+			Eventually(func(g Gomega) {
+				c := GetCinder(cinderTest.Instance)
+				g.Expect(c.Status.ApplicationCredentialSecret).To(Equal(acSecretName))
+			}, timeout, interval).Should(Succeed())
+		})
+
+		It("should move the finalizer from the old to the new secret on rotation", func() {
+			Eventually(func(g Gomega) {
+				secret := th.GetSecret(types.NamespacedName{
+					Namespace: cinderTest.Instance.Namespace,
+					Name:      acSecretName,
+				})
+				g.Expect(secret.Finalizers).To(
+					ContainElement(cinder.ACConsumerFinalizer))
+			}, timeout, interval).Should(Succeed())
+
+			th.SimulateJobSuccess(cinderTest.CinderDBSync)
+			th.SimulateJobSuccess(cinderTest.CinderOnlineDataMigration)
+			th.SimulateStatefulSetReplicaReady(cinderTest.CinderAPI)
+			th.SimulateStatefulSetReplicaReady(cinderTest.CinderScheduler)
+			th.SimulateStatefulSetReplicaReady(cinderTest.CinderVolumes[0])
+			Eventually(func(g Gomega) {
+				c := GetCinder(cinderTest.Instance)
+				g.Expect(c.Status.Conditions.IsTrue(condition.ReadyCondition)).To(BeTrue())
+			}, timeout, interval).Should(Succeed())
+
+			newACSecretName := "ac-cinder-x9y8z-secret" //nolint:gosec // G101
+			newSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: cinderTest.Instance.Namespace,
+					Name:      newACSecretName,
+				},
+				Data: map[string][]byte{
+					keystonev1.ACIDSecretKey:     []byte("x9y8zrotated-ac-id"),
+					keystonev1.ACSecretSecretKey: []byte("rotated-ac-secret"),
+				},
+			}
+			DeferCleanup(k8sClient.Delete, ctx, newSecret)
+			Expect(k8sClient.Create(ctx, newSecret)).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				c := GetCinder(cinderTest.Instance)
+				c.Spec.Auth.ApplicationCredentialSecret = newACSecretName
+				g.Expect(k8sClient.Update(ctx, c)).Should(Succeed())
+			}, timeout, interval).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				secret := th.GetSecret(types.NamespacedName{
+					Namespace: cinderTest.Instance.Namespace,
+					Name:      newACSecretName,
+				})
+				g.Expect(secret.Finalizers).To(
+					ContainElement(cinder.ACConsumerFinalizer))
+			}, timeout, interval).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				th.SimulateJobSuccess(cinderTest.CinderOnlineDataMigration)
+				th.SimulateStatefulSetReplicaReady(cinderTest.CinderAPI)
+				th.SimulateStatefulSetReplicaReady(cinderTest.CinderScheduler)
+				th.SimulateStatefulSetReplicaReady(cinderTest.CinderVolumes[0])
+				secret := th.GetSecret(types.NamespacedName{
+					Namespace: cinderTest.Instance.Namespace,
+					Name:      acSecretName,
+				})
+				g.Expect(secret.Finalizers).NotTo(
+					ContainElement(cinder.ACConsumerFinalizer))
+			}, timeout, interval).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				c := GetCinder(cinderTest.Instance)
+				g.Expect(c.Status.ApplicationCredentialSecret).To(Equal(newACSecretName))
+			}, timeout, interval).Should(Succeed())
+		})
+
+		It("should remove finalizer and clear status when AC secret is removed from spec", func() {
+			th.SimulateJobSuccess(cinderTest.CinderDBSync)
+			th.SimulateJobSuccess(cinderTest.CinderOnlineDataMigration)
+			th.SimulateStatefulSetReplicaReady(cinderTest.CinderAPI)
+			th.SimulateStatefulSetReplicaReady(cinderTest.CinderScheduler)
+			th.SimulateStatefulSetReplicaReady(cinderTest.CinderVolumes[0])
+			Eventually(func(g Gomega) {
+				c := GetCinder(cinderTest.Instance)
+				g.Expect(c.Status.Conditions.IsTrue(condition.ReadyCondition)).To(BeTrue())
+				g.Expect(c.Status.ApplicationCredentialSecret).To(Equal(acSecretName))
+			}, timeout, interval).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				c := GetCinder(cinderTest.Instance)
+				c.Spec.Auth.ApplicationCredentialSecret = ""
+				g.Expect(k8sClient.Update(ctx, c)).Should(Succeed())
+			}, timeout, interval).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				th.SimulateJobSuccess(cinderTest.CinderOnlineDataMigration)
+				th.SimulateStatefulSetReplicaReady(cinderTest.CinderAPI)
+				th.SimulateStatefulSetReplicaReady(cinderTest.CinderScheduler)
+				th.SimulateStatefulSetReplicaReady(cinderTest.CinderVolumes[0])
+				secret := th.GetSecret(types.NamespacedName{
+					Namespace: cinderTest.Instance.Namespace,
+					Name:      acSecretName,
+				})
+				g.Expect(secret.Finalizers).NotTo(
+					ContainElement(cinder.ACConsumerFinalizer))
+			}, timeout, interval).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				c := GetCinder(cinderTest.Instance)
+				g.Expect(c.Status.ApplicationCredentialSecret).To(Equal(""))
+			}, timeout, interval).Should(Succeed())
+		})
+
+		It("should remove the consumer finalizer from AC secret on CR deletion", func() {
+			Eventually(func(g Gomega) {
+				secret := th.GetSecret(types.NamespacedName{
+					Namespace: cinderTest.Instance.Namespace,
+					Name:      acSecretName,
+				})
+				g.Expect(secret.Finalizers).To(
+					ContainElement(cinder.ACConsumerFinalizer))
+			}, timeout, interval).Should(Succeed())
+
+			th.DeleteInstance(GetCinder(cinderTest.Instance))
+
+			Eventually(func(g Gomega) {
+				secret := th.GetSecret(types.NamespacedName{
+					Namespace: cinderTest.Instance.Namespace,
+					Name:      acSecretName,
+				})
+				g.Expect(secret.Finalizers).NotTo(
+					ContainElement(cinder.ACConsumerFinalizer))
+			}, timeout, interval).Should(Succeed())
+		})
+	})
 })
 
 var _ = Describe("Cinder with RabbitMQ custom vhost and user", func() {


### PR DESCRIPTION
Jira: [OSPRH-27509](https://redhat.atlassian.net/browse/OSPRH-27509)

Application Credential dev-doc: https://github.com/openstack-k8s-operators/dev-docs/blob/main/application_credentials.md

* Tracks the active AC secret name in `Status.ApplicationCredentialSecret`
* Add `openstack.org/cinder-ac-consumer` finalizer to the AC secret after service config is rendered
* On AC rotation, move the finalizer from the old secret to the new one
* On CR deletion, remove the consumer finalizer from the AC secret before cleaning up the CR

This ensures that the keystone-operator cannot revoke a rotated AC secret while Cinder is still consuming it.

```
2026-04-28T11:50:13Z	INFO	Controllers.Cinder	Added consumer finalizer	{"controller": "cinder", "controllerGroup": "cinder.openstack.org", "controllerKind": "Cinder", "Cinder": {"name":"cinder","namespace":"openstack"}, "namespace": "openstack", "name": "cinder", "reconcileID": "7dcaf45c-7fe4-4c3f-ad58-9ffd2efd83fb", "object": "ac-cinder-5f914-secret", "finalizer": "openstack.org/cinder-ac-consumer"}
2026-04-28T11:50:13Z	INFO	Controllers.Cinder	Removed consumer finalizer	{"controller": "cinder", "controllerGroup": "cinder.openstack.org", "controllerKind": "Cinder", "Cinder": {"name":"cinder","namespace":"openstack"}, "namespace": "openstack", "name": "cinder", "reconcileID": "7dcaf45c-7fe4-4c3f-ad58-9ffd2efd83fb", "object": "ac-cinder-7e49e-secret", "finalizer": "openstack.org/cinder-ac-consumer"}
```

Depends-On: https://github.com/openstack-k8s-operators/keystone-operator/pull/685

Assisted-by: Claude Opus 4.6 [noreply@anthropic.com](mailto:noreply@anthropic.com)