### PR TITLE
Add glance section required by Cinder to use new glance location-api

### DIFF
--- a/templates/cinder/config/00-global-defaults.conf
+++ b/templates/cinder/config/00-global-defaults.conf
@@ -122,6 +122,25 @@ project_domain_name = Default
 region_name = {{ .Region }}
 {{ end -}}
 
+[glance]
+interface = internal
+auth_url = {{ .KeystoneInternalURL }}
+{{ if (index . "ApplicationCredentialID") -}}
+auth_type = v3applicationcredential
+application_credential_id = {{ .ApplicationCredentialID }}
+application_credential_secret = {{ .ApplicationCredentialSecret }}
+{{ else -}}
+auth_type = password
+username = {{ .ServiceUser }}
+password = {{ .ServicePassword }}
+user_domain_name = Default
+project_name = service
+project_domain_name = Default
+{{ end -}}
+{{ if (index . "Region") -}}
+region_name = {{ .Region }}
+{{ end -}}
+
 [service_user]
 send_service_user_token = True
 auth_url = {{ .KeystoneInternalURL }}


### PR DESCRIPTION
We need to register `glance` user in `keystoneauth` plugin to allow service to service communication and let `Cinder` access to the location-api glance calls. [1].

Jira: [OSPRH-28617](https://redhat.atlassian.net/browse/OSPRH-28617)

[1] https://review.opendev.org/c/openstack/cinder/+/958716