### PR TITLE
Do not run zuul jobs on irrelevant files changes

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -5,7 +5,7 @@
     attempts: 1
     required-projects:
       - github.com/openstack-k8s-operators/cinder-operator
-    irrelevant-files:
+    irrelevant-files: &common-irrelevant-files
       - .*/*.md
       - ^\..*$
       - ^LICENSE$
@@ -22,6 +22,7 @@
 - job:
     name: cinder-operator-tempest
     parent: podified-multinode-hci-deployment-crc-1comp-backends
+    irrelevant-files: *common-irrelevant-files
     vars:
       cifmw_test_operator_tempest_concurrency: 3
       cifmw_test_operator_tempest_include_list: |


### PR DESCRIPTION
Like we did in glance-operator [1], do not waste CI cycles when we update documentation or files not related to code changes.

[1] https://github.com/openstack-k8s-operators/glance-operator/blob/main/zuul.d/jobs.yaml#L8